### PR TITLE
Updates for OSX compiling.

### DIFF
--- a/Xcode/mana/mana-Info.plist
+++ b/Xcode/mana/mana-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
-	<string>mana.icns</string>
+	<string>../data/icons/mana.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.mana.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/Xcode/mana10.7.xcodeproj/project.pbxproj
+++ b/Xcode/mana10.7.xcodeproj/project.pbxproj
@@ -1,0 +1,2112 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2FBA050D15B8EE77001AB720 /* SDL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FBA050315B8ED49001AB720 /* SDL.framework */; };
+		2FBA050E15B8EFBF001AB720 /* SDL_image.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FBA050715B8ED6D001AB720 /* SDL_image.framework */; };
+		2FBA050F15B8EFBF001AB720 /* SDL_mixer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FBA050515B8ED59001AB720 /* SDL_mixer.framework */; };
+		FC0479CB151E4DB700C5E9E7 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC0479CA151E4DB700C5E9E7 /* Cocoa.framework */; };
+		FC0479D5151E4DB700C5E9E7 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = FC0479D3151E4DB700C5E9E7 /* InfoPlist.strings */; };
+		FC0479E1151E4DB800C5E9E7 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC0479DF151E4DB800C5E9E7 /* MainMenu.xib */; };
+		FC047A13151E4F8800C5E9E7 /* actor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479E7151E4F8800C5E9E7 /* actor.cpp */; };
+		FC047A14151E4F8800C5E9E7 /* actorsprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479E9151E4F8800C5E9E7 /* actorsprite.cpp */; };
+		FC047A15151E4F8800C5E9E7 /* actorspritemanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479EB151E4F8800C5E9E7 /* actorspritemanager.cpp */; };
+		FC047A16151E4F8800C5E9E7 /* animatedsprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479ED151E4F8800C5E9E7 /* animatedsprite.cpp */; };
+		FC047A17151E4F8800C5E9E7 /* animationparticle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479EF151E4F8800C5E9E7 /* animationparticle.cpp */; };
+		FC047A18151E4F8800C5E9E7 /* avatar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479F1151E4F8800C5E9E7 /* avatar.cpp */; };
+		FC047A19151E4F8800C5E9E7 /* being.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479F3151E4F8800C5E9E7 /* being.cpp */; };
+		FC047A1A151E4F8800C5E9E7 /* channel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479F5151E4F8800C5E9E7 /* channel.cpp */; };
+		FC047A1B151E4F8800C5E9E7 /* channelmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479F7151E4F8800C5E9E7 /* channelmanager.cpp */; };
+		FC047A1C151E4F8800C5E9E7 /* chatlogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479F9151E4F8800C5E9E7 /* chatlogger.cpp */; };
+		FC047A1D151E4F8800C5E9E7 /* client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479FB151E4F8800C5E9E7 /* client.cpp */; };
+		FC047A1E151E4F8800C5E9E7 /* commandhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479FD151E4F8800C5E9E7 /* commandhandler.cpp */; };
+		FC047A1F151E4F8800C5E9E7 /* compoundsprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC0479FF151E4F8800C5E9E7 /* compoundsprite.cpp */; };
+		FC047A20151E4F8800C5E9E7 /* configuration.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A01151E4F8800C5E9E7 /* configuration.cpp */; };
+		FC047A21151E4F8800C5E9E7 /* defaults.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A03151E4F8800C5E9E7 /* defaults.cpp */; };
+		FC047A22151E4F8800C5E9E7 /* effectmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A05151E4F8800C5E9E7 /* effectmanager.cpp */; };
+		FC047A23151E4F8800C5E9E7 /* emoteshortcut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A07151E4F8800C5E9E7 /* emoteshortcut.cpp */; };
+		FC047A24151E4F8800C5E9E7 /* event.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A0A151E4F8800C5E9E7 /* event.cpp */; };
+		FC047A25151E4F8800C5E9E7 /* eventlistener.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A0C151E4F8800C5E9E7 /* eventlistener.cpp */; };
+		FC047A26151E4F8800C5E9E7 /* flooritem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A0E151E4F8800C5E9E7 /* flooritem.cpp */; };
+		FC047A27151E4F8800C5E9E7 /* game.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A10151E4F8800C5E9E7 /* game.cpp */; };
+		FC047A28151E4F8800C5E9E7 /* graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A12151E4F8800C5E9E7 /* graphics.cpp */; };
+		FC047A6F151E4FC700C5E9E7 /* guild.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A2B151E4FC700C5E9E7 /* guild.cpp */; };
+		FC047A70151E4FC700C5E9E7 /* imageparticle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A2D151E4FC700C5E9E7 /* imageparticle.cpp */; };
+		FC047A71151E4FC700C5E9E7 /* imagesprite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A2F151E4FC700C5E9E7 /* imagesprite.cpp */; };
+		FC047A72151E4FC700C5E9E7 /* inventory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A31151E4FC700C5E9E7 /* inventory.cpp */; };
+		FC047A73151E4FC700C5E9E7 /* item.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A33151E4FC700C5E9E7 /* item.cpp */; };
+		FC047A74151E4FC700C5E9E7 /* itemshortcut.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A35151E4FC700C5E9E7 /* itemshortcut.cpp */; };
+		FC047A75151E4FC700C5E9E7 /* joystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A37151E4FC700C5E9E7 /* joystick.cpp */; };
+		FC047A76151E4FC700C5E9E7 /* keyboardconfig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A39151E4FC700C5E9E7 /* keyboardconfig.cpp */; };
+		FC047A77151E4FC700C5E9E7 /* localplayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A3B151E4FC700C5E9E7 /* localplayer.cpp */; };
+		FC047A78151E4FC700C5E9E7 /* log.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A3D151E4FC700C5E9E7 /* log.cpp */; };
+		FC047A79151E4FC700C5E9E7 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A3F151E4FC700C5E9E7 /* main.cpp */; };
+		FC047A7A151E4FC700C5E9E7 /* map.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A41151E4FC700C5E9E7 /* map.cpp */; };
+		FC047A7B151E4FC700C5E9E7 /* openglgraphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A43151E4FC700C5E9E7 /* openglgraphics.cpp */; };
+		FC047A7C151E4FC700C5E9E7 /* particle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A45151E4FC700C5E9E7 /* particle.cpp */; };
+		FC047A7D151E4FC700C5E9E7 /* particlecontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A47151E4FC700C5E9E7 /* particlecontainer.cpp */; };
+		FC047A7E151E4FC700C5E9E7 /* particleemitter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A49151E4FC700C5E9E7 /* particleemitter.cpp */; };
+		FC047A7F151E4FC700C5E9E7 /* party.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A4C151E4FC700C5E9E7 /* party.cpp */; };
+		FC047A80151E4FC700C5E9E7 /* playerinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A4E151E4FC700C5E9E7 /* playerinfo.cpp */; };
+		FC047A81151E4FC700C5E9E7 /* playerrelations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A50151E4FC700C5E9E7 /* playerrelations.cpp */; };
+		FC047A82151E4FC700C5E9E7 /* position.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A52151E4FC700C5E9E7 /* position.cpp */; };
+		FC047A83151E4FC700C5E9E7 /* rotationalparticle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A55151E4FC700C5E9E7 /* rotationalparticle.cpp */; };
+		FC047A84151E4FC700C5E9E7 /* SDLMain.m in Sources */ = {isa = PBXBuildFile; fileRef = FC047A58151E4FC700C5E9E7 /* SDLMain.m */; };
+		FC047A85151E4FC700C5E9E7 /* shopitem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A59151E4FC700C5E9E7 /* shopitem.cpp */; };
+		FC047A86151E4FC700C5E9E7 /* simpleanimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A5B151E4FC700C5E9E7 /* simpleanimation.cpp */; };
+		FC047A87151E4FC700C5E9E7 /* sound.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A5D151E4FC700C5E9E7 /* sound.cpp */; };
+		FC047A88151E4FC700C5E9E7 /* statuseffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A60151E4FC700C5E9E7 /* statuseffect.cpp */; };
+		FC047A89151E4FC700C5E9E7 /* text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A62151E4FC700C5E9E7 /* text.cpp */; };
+		FC047A8A151E4FC700C5E9E7 /* textmanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A64151E4FC700C5E9E7 /* textmanager.cpp */; };
+		FC047A8B151E4FC700C5E9E7 /* textparticle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A66151E4FC700C5E9E7 /* textparticle.cpp */; };
+		FC047A8C151E4FC700C5E9E7 /* units.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A6A151E4FC700C5E9E7 /* units.cpp */; };
+		FC047A8D151E4FC700C5E9E7 /* vector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A6D151E4FC700C5E9E7 /* vector.cpp */; };
+		FC047B5F151E4FF700C5E9E7 /* beingpopup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A8F151E4FF700C5E9E7 /* beingpopup.cpp */; };
+		FC047B60151E4FF700C5E9E7 /* buydialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A91151E4FF700C5E9E7 /* buydialog.cpp */; };
+		FC047B61151E4FF700C5E9E7 /* buyselldialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A93151E4FF700C5E9E7 /* buyselldialog.cpp */; };
+		FC047B62151E4FF700C5E9E7 /* changeemaildialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A95151E4FF700C5E9E7 /* changeemaildialog.cpp */; };
+		FC047B63151E4FF700C5E9E7 /* changepassworddialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A97151E4FF700C5E9E7 /* changepassworddialog.cpp */; };
+		FC047B64151E4FF700C5E9E7 /* charcreatedialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A99151E4FF700C5E9E7 /* charcreatedialog.cpp */; };
+		FC047B65151E4FF700C5E9E7 /* charselectdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A9B151E4FF700C5E9E7 /* charselectdialog.cpp */; };
+		FC047B66151E4FF700C5E9E7 /* chatwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A9D151E4FF700C5E9E7 /* chatwindow.cpp */; };
+		FC047B67151E4FF700C5E9E7 /* confirmdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047A9F151E4FF700C5E9E7 /* confirmdialog.cpp */; };
+		FC047B68151E4FF700C5E9E7 /* connectiondialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AA1151E4FF700C5E9E7 /* connectiondialog.cpp */; };
+		FC047B69151E4FF700C5E9E7 /* customserverdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AA3151E4FF700C5E9E7 /* customserverdialog.cpp */; };
+		FC047B6A151E4FF700C5E9E7 /* debugwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AA5151E4FF700C5E9E7 /* debugwindow.cpp */; };
+		FC047B6B151E4FF700C5E9E7 /* emotepopup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AA7151E4FF700C5E9E7 /* emotepopup.cpp */; };
+		FC047B6C151E4FF700C5E9E7 /* equipmentwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AA9151E4FF700C5E9E7 /* equipmentwindow.cpp */; };
+		FC047B6D151E4FF700C5E9E7 /* focushandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AAB151E4FF700C5E9E7 /* focushandler.cpp */; };
+		FC047B6E151E4FF700C5E9E7 /* gui.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AAD151E4FF700C5E9E7 /* gui.cpp */; };
+		FC047B6F151E4FF700C5E9E7 /* helpwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AAF151E4FF700C5E9E7 /* helpwindow.cpp */; };
+		FC047B70151E4FF700C5E9E7 /* inventorywindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AB1151E4FF700C5E9E7 /* inventorywindow.cpp */; };
+		FC047B71151E4FF700C5E9E7 /* itemamountwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AB3151E4FF700C5E9E7 /* itemamountwindow.cpp */; };
+		FC047B72151E4FF700C5E9E7 /* itempopup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AB5151E4FF700C5E9E7 /* itempopup.cpp */; };
+		FC047B73151E4FF700C5E9E7 /* logindialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AB7151E4FF700C5E9E7 /* logindialog.cpp */; };
+		FC047B74151E4FF700C5E9E7 /* minimap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AB9151E4FF700C5E9E7 /* minimap.cpp */; };
+		FC047B75151E4FF700C5E9E7 /* ministatuswindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ABB151E4FF700C5E9E7 /* ministatuswindow.cpp */; };
+		FC047B76151E4FF700C5E9E7 /* npcdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ABD151E4FF700C5E9E7 /* npcdialog.cpp */; };
+		FC047B77151E4FF700C5E9E7 /* npcpostdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ABF151E4FF700C5E9E7 /* npcpostdialog.cpp */; };
+		FC047B78151E4FF700C5E9E7 /* okdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AC1151E4FF700C5E9E7 /* okdialog.cpp */; };
+		FC047B79151E4FF700C5E9E7 /* outfitwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AC3151E4FF700C5E9E7 /* outfitwindow.cpp */; };
+		FC047B7A151E4FF700C5E9E7 /* palette.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AC5151E4FF700C5E9E7 /* palette.cpp */; };
+		FC047B7B151E4FF700C5E9E7 /* popupmenu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AC7151E4FF700C5E9E7 /* popupmenu.cpp */; };
+		FC047B7C151E4FF700C5E9E7 /* quitdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AC9151E4FF700C5E9E7 /* quitdialog.cpp */; };
+		FC047B7D151E4FF700C5E9E7 /* recorder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ACB151E4FF700C5E9E7 /* recorder.cpp */; };
+		FC047B7E151E4FF700C5E9E7 /* register.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ACD151E4FF700C5E9E7 /* register.cpp */; };
+		FC047B7F151E4FF700C5E9E7 /* sdlinput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ACF151E4FF700C5E9E7 /* sdlinput.cpp */; };
+		FC047B80151E4FF700C5E9E7 /* selldialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AD1151E4FF700C5E9E7 /* selldialog.cpp */; };
+		FC047B81151E4FF700C5E9E7 /* serverdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AD3151E4FF700C5E9E7 /* serverdialog.cpp */; };
+		FC047B82151E4FF700C5E9E7 /* setup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AD5151E4FF700C5E9E7 /* setup.cpp */; };
+		FC047B83151E4FF700C5E9E7 /* setup_audio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AD7151E4FF700C5E9E7 /* setup_audio.cpp */; };
+		FC047B84151E4FF700C5E9E7 /* setup_colors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AD9151E4FF700C5E9E7 /* setup_colors.cpp */; };
+		FC047B85151E4FF700C5E9E7 /* setup_interface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ADB151E4FF700C5E9E7 /* setup_interface.cpp */; };
+		FC047B86151E4FF700C5E9E7 /* setup_joystick.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ADD151E4FF700C5E9E7 /* setup_joystick.cpp */; };
+		FC047B87151E4FF700C5E9E7 /* setup_keyboard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047ADF151E4FF700C5E9E7 /* setup_keyboard.cpp */; };
+		FC047B88151E4FF700C5E9E7 /* setup_players.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AE1151E4FF700C5E9E7 /* setup_players.cpp */; };
+		FC047B89151E4FF700C5E9E7 /* setup_video.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AE3151E4FF700C5E9E7 /* setup_video.cpp */; };
+		FC047B8A151E4FF700C5E9E7 /* shortcutwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AE5151E4FF700C5E9E7 /* shortcutwindow.cpp */; };
+		FC047B8B151E4FF700C5E9E7 /* skilldialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AE7151E4FF700C5E9E7 /* skilldialog.cpp */; };
+		FC047B8C151E4FF700C5E9E7 /* socialwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AE9151E4FF700C5E9E7 /* socialwindow.cpp */; };
+		FC047B8D151E4FF700C5E9E7 /* specialswindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AEB151E4FF700C5E9E7 /* specialswindow.cpp */; };
+		FC047B8E151E4FF700C5E9E7 /* speechbubble.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AED151E4FF700C5E9E7 /* speechbubble.cpp */; };
+		FC047B8F151E4FF700C5E9E7 /* statuswindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AEF151E4FF700C5E9E7 /* statuswindow.cpp */; };
+		FC047B90151E4FF700C5E9E7 /* textdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AF1151E4FF700C5E9E7 /* textdialog.cpp */; };
+		FC047B91151E4FF700C5E9E7 /* textpopup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AF3151E4FF700C5E9E7 /* textpopup.cpp */; };
+		FC047B92151E4FF700C5E9E7 /* tradewindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AF5151E4FF700C5E9E7 /* tradewindow.cpp */; };
+		FC047B93151E4FF700C5E9E7 /* truetypefont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AF7151E4FF700C5E9E7 /* truetypefont.cpp */; };
+		FC047B94151E4FF700C5E9E7 /* unregisterdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AF9151E4FF700C5E9E7 /* unregisterdialog.cpp */; };
+		FC047B95151E4FF700C5E9E7 /* updaterwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AFB151E4FF700C5E9E7 /* updaterwindow.cpp */; };
+		FC047B96151E4FF700C5E9E7 /* viewport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047AFD151E4FF700C5E9E7 /* viewport.cpp */; };
+		FC047B97151E4FF700C5E9E7 /* avatarlistbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B00151E4FF700C5E9E7 /* avatarlistbox.cpp */; };
+		FC047B98151E4FF700C5E9E7 /* browserbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B02151E4FF700C5E9E7 /* browserbox.cpp */; };
+		FC047B99151E4FF700C5E9E7 /* button.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B04151E4FF700C5E9E7 /* button.cpp */; };
+		FC047B9A151E4FF700C5E9E7 /* channeltab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B06151E4FF700C5E9E7 /* channeltab.cpp */; };
+		FC047B9B151E4FF700C5E9E7 /* chattab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B08151E4FF700C5E9E7 /* chattab.cpp */; };
+		FC047B9C151E4FF700C5E9E7 /* checkbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B0A151E4FF700C5E9E7 /* checkbox.cpp */; };
+		FC047B9D151E4FF700C5E9E7 /* container.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B0C151E4FF700C5E9E7 /* container.cpp */; };
+		FC047B9E151E4FF700C5E9E7 /* desktop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B0E151E4FF700C5E9E7 /* desktop.cpp */; };
+		FC047B9F151E4FF700C5E9E7 /* dropdown.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B10151E4FF700C5E9E7 /* dropdown.cpp */; };
+		FC047BA0151E4FF700C5E9E7 /* emoteshortcutcontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B12151E4FF700C5E9E7 /* emoteshortcutcontainer.cpp */; };
+		FC047BA1151E4FF700C5E9E7 /* flowcontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B14151E4FF700C5E9E7 /* flowcontainer.cpp */; };
+		FC047BA2151E4FF700C5E9E7 /* icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B16151E4FF700C5E9E7 /* icon.cpp */; };
+		FC047BA3151E4FF700C5E9E7 /* inttextfield.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B18151E4FF700C5E9E7 /* inttextfield.cpp */; };
+		FC047BA4151E4FF700C5E9E7 /* itemcontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B1A151E4FF700C5E9E7 /* itemcontainer.cpp */; };
+		FC047BA5151E4FF700C5E9E7 /* itemlinkhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B1C151E4FF700C5E9E7 /* itemlinkhandler.cpp */; };
+		FC047BA6151E4FF700C5E9E7 /* itemshortcutcontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B1E151E4FF700C5E9E7 /* itemshortcutcontainer.cpp */; };
+		FC047BA7151E4FF700C5E9E7 /* label.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B20151E4FF700C5E9E7 /* label.cpp */; };
+		FC047BA8151E4FF700C5E9E7 /* layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B22151E4FF700C5E9E7 /* layout.cpp */; };
+		FC047BA9151E4FF700C5E9E7 /* layouthelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B24151E4FF700C5E9E7 /* layouthelper.cpp */; };
+		FC047BAA151E4FF700C5E9E7 /* listbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B27151E4FF700C5E9E7 /* listbox.cpp */; };
+		FC047BAB151E4FF700C5E9E7 /* passwordfield.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B29151E4FF700C5E9E7 /* passwordfield.cpp */; };
+		FC047BAC151E4FF700C5E9E7 /* playerbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B2B151E4FF700C5E9E7 /* playerbox.cpp */; };
+		FC047BAD151E4FF700C5E9E7 /* popup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B2D151E4FF700C5E9E7 /* popup.cpp */; };
+		FC047BAE151E4FF700C5E9E7 /* progressbar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B2F151E4FF700C5E9E7 /* progressbar.cpp */; };
+		FC047BAF151E4FF700C5E9E7 /* progressindicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B31151E4FF700C5E9E7 /* progressindicator.cpp */; };
+		FC047BB0151E4FF700C5E9E7 /* radiobutton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B33151E4FF700C5E9E7 /* radiobutton.cpp */; };
+		FC047BB1151E4FF700C5E9E7 /* resizegrip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B35151E4FF700C5E9E7 /* resizegrip.cpp */; };
+		FC047BB2151E4FF700C5E9E7 /* scrollarea.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B37151E4FF700C5E9E7 /* scrollarea.cpp */; };
+		FC047BB3151E4FF700C5E9E7 /* setuptab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B39151E4FF700C5E9E7 /* setuptab.cpp */; };
+		FC047BB4151E4FF700C5E9E7 /* shopitems.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B3B151E4FF700C5E9E7 /* shopitems.cpp */; };
+		FC047BB5151E4FF700C5E9E7 /* shoplistbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B3D151E4FF700C5E9E7 /* shoplistbox.cpp */; };
+		FC047BB6151E4FF700C5E9E7 /* shortcutcontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B3F151E4FF700C5E9E7 /* shortcutcontainer.cpp */; };
+		FC047BB7151E4FF700C5E9E7 /* slider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B41151E4FF700C5E9E7 /* slider.cpp */; };
+		FC047BB8151E4FF700C5E9E7 /* spacer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B43151E4FF700C5E9E7 /* spacer.cpp */; };
+		FC047BB9151E4FF700C5E9E7 /* tab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B45151E4FF700C5E9E7 /* tab.cpp */; };
+		FC047BBA151E4FF700C5E9E7 /* tabbedarea.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B47151E4FF700C5E9E7 /* tabbedarea.cpp */; };
+		FC047BBB151E4FF700C5E9E7 /* table.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B49151E4FF700C5E9E7 /* table.cpp */; };
+		FC047BBC151E4FF700C5E9E7 /* tablemodel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B4B151E4FF700C5E9E7 /* tablemodel.cpp */; };
+		FC047BBD151E4FF700C5E9E7 /* textbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B4D151E4FF700C5E9E7 /* textbox.cpp */; };
+		FC047BBE151E4FF700C5E9E7 /* textfield.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B4F151E4FF700C5E9E7 /* textfield.cpp */; };
+		FC047BBF151E4FF700C5E9E7 /* textpreview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B51151E4FF700C5E9E7 /* textpreview.cpp */; };
+		FC047BC0151E4FF700C5E9E7 /* vertcontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B53151E4FF700C5E9E7 /* vertcontainer.cpp */; };
+		FC047BC1151E4FF700C5E9E7 /* whispertab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B55151E4FF700C5E9E7 /* whispertab.cpp */; };
+		FC047BC2151E4FF700C5E9E7 /* window.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B57151E4FF700C5E9E7 /* window.cpp */; };
+		FC047BC3151E4FF700C5E9E7 /* windowcontainer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B59151E4FF700C5E9E7 /* windowcontainer.cpp */; };
+		FC047BC4151E4FF700C5E9E7 /* windowmenu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B5B151E4FF700C5E9E7 /* windowmenu.cpp */; };
+		FC047BC5151E4FF700C5E9E7 /* worldselectdialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047B5D151E4FF700C5E9E7 /* worldselectdialog.cpp */; };
+		FC047C44151E500100C5E9E7 /* charhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BC8151E500100C5E9E7 /* charhandler.cpp */; };
+		FC047C45151E500100C5E9E7 /* download.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BCB151E500100C5E9E7 /* download.cpp */; };
+		FC047C46151E500100C5E9E7 /* adminhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BD4151E500100C5E9E7 /* adminhandler.cpp */; };
+		FC047C47151E500100C5E9E7 /* attributes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BD6151E500100C5E9E7 /* attributes.cpp */; };
+		FC047C48151E500100C5E9E7 /* beinghandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BD8151E500100C5E9E7 /* beinghandler.cpp */; };
+		FC047C49151E500100C5E9E7 /* buysellhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BDA151E500100C5E9E7 /* buysellhandler.cpp */; };
+		FC047C4A151E500100C5E9E7 /* charhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BDC151E500100C5E9E7 /* charhandler.cpp */; };
+		FC047C4B151E500100C5E9E7 /* chathandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BDE151E500100C5E9E7 /* chathandler.cpp */; };
+		FC047C4C151E500100C5E9E7 /* connection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BE0151E500100C5E9E7 /* connection.cpp */; };
+		FC047C4D151E500100C5E9E7 /* effecthandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BE3151E500100C5E9E7 /* effecthandler.cpp */; };
+		FC047C4E151E500100C5E9E7 /* gamehandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BE5151E500100C5E9E7 /* gamehandler.cpp */; };
+		FC047C4F151E500100C5E9E7 /* generalhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BE7151E500100C5E9E7 /* generalhandler.cpp */; };
+		FC047C50151E500100C5E9E7 /* guildhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BE9151E500100C5E9E7 /* guildhandler.cpp */; };
+		FC047C51151E500100C5E9E7 /* internal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BEB151E500100C5E9E7 /* internal.cpp */; };
+		FC047C52151E500100C5E9E7 /* inventoryhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BED151E500100C5E9E7 /* inventoryhandler.cpp */; };
+		FC047C53151E500100C5E9E7 /* itemhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BEF151E500100C5E9E7 /* itemhandler.cpp */; };
+		FC047C54151E500100C5E9E7 /* loginhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BF1151E500100C5E9E7 /* loginhandler.cpp */; };
+		FC047C55151E500100C5E9E7 /* messagehandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BF4151E500100C5E9E7 /* messagehandler.cpp */; };
+		FC047C56151E500100C5E9E7 /* messagein.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BF6151E500100C5E9E7 /* messagein.cpp */; };
+		FC047C57151E500100C5E9E7 /* messageout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BF8151E500100C5E9E7 /* messageout.cpp */; };
+		FC047C58151E500100C5E9E7 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BFA151E500100C5E9E7 /* network.cpp */; };
+		FC047C59151E500100C5E9E7 /* npchandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BFC151E500100C5E9E7 /* npchandler.cpp */; };
+		FC047C5A151E500100C5E9E7 /* partyhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047BFE151E500100C5E9E7 /* partyhandler.cpp */; };
+		FC047C5B151E500100C5E9E7 /* playerhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C00151E500100C5E9E7 /* playerhandler.cpp */; };
+		FC047C5C151E500100C5E9E7 /* specialhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C02151E500100C5E9E7 /* specialhandler.cpp */; };
+		FC047C5D151E500100C5E9E7 /* tradehandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C04151E500100C5E9E7 /* tradehandler.cpp */; };
+		FC047C60151E500100C5E9E7 /* net.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C0B151E500100C5E9E7 /* net.cpp */; };
+		FC047C61151E500100C5E9E7 /* adminhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C13151E500100C5E9E7 /* adminhandler.cpp */; };
+		FC047C62151E500100C5E9E7 /* beinghandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C15151E500100C5E9E7 /* beinghandler.cpp */; };
+		FC047C63151E500100C5E9E7 /* buysellhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C17151E500100C5E9E7 /* buysellhandler.cpp */; };
+		FC047C64151E500100C5E9E7 /* charserverhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C19151E500100C5E9E7 /* charserverhandler.cpp */; };
+		FC047C65151E500100C5E9E7 /* chathandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C1B151E500100C5E9E7 /* chathandler.cpp */; };
+		FC047C66151E500100C5E9E7 /* gamehandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C1D151E500100C5E9E7 /* gamehandler.cpp */; };
+		FC047C67151E500100C5E9E7 /* generalhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C1F151E500100C5E9E7 /* generalhandler.cpp */; };
+		FC047C68151E500100C5E9E7 /* guildtab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C22151E500100C5E9E7 /* guildtab.cpp */; };
+		FC047C69151E500100C5E9E7 /* partytab.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C24151E500100C5E9E7 /* partytab.cpp */; };
+		FC047C6A151E500100C5E9E7 /* guildhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C26151E500100C5E9E7 /* guildhandler.cpp */; };
+		FC047C6B151E500100C5E9E7 /* inventoryhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C28151E500100C5E9E7 /* inventoryhandler.cpp */; };
+		FC047C6C151E500100C5E9E7 /* itemhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C2A151E500100C5E9E7 /* itemhandler.cpp */; };
+		FC047C6D151E500100C5E9E7 /* loginhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C2C151E500100C5E9E7 /* loginhandler.cpp */; };
+		FC047C6E151E500100C5E9E7 /* messagehandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C2E151E500100C5E9E7 /* messagehandler.cpp */; };
+		FC047C6F151E500100C5E9E7 /* messagein.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C30151E500100C5E9E7 /* messagein.cpp */; };
+		FC047C70151E500100C5E9E7 /* messageout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C32151E500100C5E9E7 /* messageout.cpp */; };
+		FC047C71151E500100C5E9E7 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C34151E500100C5E9E7 /* network.cpp */; };
+		FC047C72151E500100C5E9E7 /* npchandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C36151E500100C5E9E7 /* npchandler.cpp */; };
+		FC047C73151E500100C5E9E7 /* partyhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C38151E500100C5E9E7 /* partyhandler.cpp */; };
+		FC047C74151E500100C5E9E7 /* playerhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C3A151E500100C5E9E7 /* playerhandler.cpp */; };
+		FC047C75151E500100C5E9E7 /* specialhandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C3D151E500100C5E9E7 /* specialhandler.cpp */; };
+		FC047C76151E500100C5E9E7 /* tradehandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C40151E500100C5E9E7 /* tradehandler.cpp */; };
+		FC047CAA151E500C00C5E9E7 /* action.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C78151E500C00C5E9E7 /* action.cpp */; };
+		FC047CAB151E500C00C5E9E7 /* ambientlayer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C7A151E500C00C5E9E7 /* ambientlayer.cpp */; };
+		FC047CAC151E500C00C5E9E7 /* animation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C7C151E500C00C5E9E7 /* animation.cpp */; };
+		FC047CAD151E500C00C5E9E7 /* beinginfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C7E151E500C00C5E9E7 /* beinginfo.cpp */; };
+		FC047CAE151E500C00C5E9E7 /* dye.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C80151E500C00C5E9E7 /* dye.cpp */; };
+		FC047CAF151E500C00C5E9E7 /* emotedb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C82151E500C00C5E9E7 /* emotedb.cpp */; };
+		FC047CB0151E500C00C5E9E7 /* hairdb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C84151E500C00C5E9E7 /* hairdb.cpp */; };
+		FC047CB1151E500C00C5E9E7 /* image.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C86151E500C00C5E9E7 /* image.cpp */; };
+		FC047CB2151E500C00C5E9E7 /* imageloader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C88151E500C00C5E9E7 /* imageloader.cpp */; };
+		FC047CB3151E500C00C5E9E7 /* imageset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C8A151E500C00C5E9E7 /* imageset.cpp */; };
+		FC047CB4151E500C00C5E9E7 /* imagewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C8C151E500C00C5E9E7 /* imagewriter.cpp */; };
+		FC047CB5151E500C00C5E9E7 /* itemdb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C8E151E500C00C5E9E7 /* itemdb.cpp */; };
+		FC047CB6151E500C00C5E9E7 /* iteminfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C90151E500C00C5E9E7 /* iteminfo.cpp */; };
+		FC047CB7151E500C00C5E9E7 /* mapreader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C92151E500C00C5E9E7 /* mapreader.cpp */; };
+		FC047CB8151E500C00C5E9E7 /* monsterdb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C94151E500C00C5E9E7 /* monsterdb.cpp */; };
+		FC047CB9151E500C00C5E9E7 /* music.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C96151E500C00C5E9E7 /* music.cpp */; };
+		FC047CBA151E500C00C5E9E7 /* npcdb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C98151E500C00C5E9E7 /* npcdb.cpp */; };
+		FC047CBB151E500C00C5E9E7 /* resource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C9A151E500C00C5E9E7 /* resource.cpp */; };
+		FC047CBC151E500C00C5E9E7 /* resourcemanager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C9C151E500C00C5E9E7 /* resourcemanager.cpp */; };
+		FC047CBD151E500C00C5E9E7 /* soundeffect.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047C9E151E500C00C5E9E7 /* soundeffect.cpp */; };
+		FC047CBE151E500C00C5E9E7 /* specialdb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CA0151E500C00C5E9E7 /* specialdb.cpp */; };
+		FC047CBF151E500C00C5E9E7 /* spritedef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CA2151E500C00C5E9E7 /* spritedef.cpp */; };
+		FC047CC0151E500C00C5E9E7 /* theme.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CA4151E500C00C5E9E7 /* theme.cpp */; };
+		FC047CC1151E500C00C5E9E7 /* userpalette.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CA6151E500C00C5E9E7 /* userpalette.cpp */; };
+		FC047CC2151E500C00C5E9E7 /* wallpaper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CA8151E500C00C5E9E7 /* wallpaper.cpp */; };
+		FC047CDA151E501400C5E9E7 /* base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CC4151E501400C5E9E7 /* base64.cpp */; };
+		FC047CDB151E501400C5E9E7 /* copynpaste.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CC6151E501400C5E9E7 /* copynpaste.cpp */; };
+		FC047CDC151E501400C5E9E7 /* mkdir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CCB151E501400C5E9E7 /* mkdir.cpp */; };
+		FC047CDD151E501400C5E9E7 /* physfsrwops.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047CCE151E501400C5E9E7 /* physfsrwops.c */; };
+		FC047CDE151E501400C5E9E7 /* sha256.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CD0151E501400C5E9E7 /* sha256.cpp */; };
+		FC047CDF151E501400C5E9E7 /* specialfolder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CD2151E501400C5E9E7 /* specialfolder.cpp */; };
+		FC047CE0151E501400C5E9E7 /* stringutils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CD4151E501400C5E9E7 /* stringutils.cpp */; };
+		FC047CE1151E501400C5E9E7 /* xml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CD6151E501400C5E9E7 /* xml.cpp */; };
+		FC047CE2151E501400C5E9E7 /* zlib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC047CD8151E501400C5E9E7 /* zlib.cpp */; };
+		FC047CE6151E747B00C5E9E7 /* log.mm in Sources */ = {isa = PBXBuildFile; fileRef = FC047CE5151E747B00C5E9E7 /* log.mm */; };
+		FC047CE9151E7C8500C5E9E7 /* cstdint in Resources */ = {isa = PBXBuildFile; fileRef = FC047CE8151E7C8500C5E9E7 /* cstdint */; };
+		FC047D04151E820000C5E9E7 /* callbacks.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047CEB151E820000C5E9E7 /* callbacks.c */; };
+		FC047D07151E820000C5E9E7 /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047CEE151E820000C5E9E7 /* compress.c */; };
+		FC047D09151E820000C5E9E7 /* host.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047CF0151E820000C5E9E7 /* host.c */; };
+		FC047D0B151E820000C5E9E7 /* list.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047CFD151E820000C5E9E7 /* list.c */; };
+		FC047D0C151E820000C5E9E7 /* packet.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047CFE151E820000C5E9E7 /* packet.c */; };
+		FC047D0D151E820000C5E9E7 /* peer.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047CFF151E820000C5E9E7 /* peer.c */; };
+		FC047D0E151E820000C5E9E7 /* protocol.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047D00151E820000C5E9E7 /* protocol.c */; };
+		FC047D10151E820000C5E9E7 /* unix.c in Sources */ = {isa = PBXBuildFile; fileRef = FC047D02151E820000C5E9E7 /* unix.c */; };
+		FC047D1A151E853300C5E9E7 /* libSDL_gfx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D15151E853200C5E9E7 /* libSDL_gfx.a */; };
+		FC047D1B151E853300C5E9E7 /* libxml2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D16151E853300C5E9E7 /* libxml2.a */; };
+		FC047D1D151E856400C5E9E7 /* libphysfs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D1C151E856400C5E9E7 /* libphysfs.a */; };
+		FC047D1F151E860600C5E9E7 /* libpng.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D1E151E860600C5E9E7 /* libpng.a */; };
+		FC047D24151E878A00C5E9E7 /* libSDL_net.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D22151E878A00C5E9E7 /* libSDL_net.a */; };
+		FC047D25151E878A00C5E9E7 /* libSDL_ttf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D23151E878A00C5E9E7 /* libSDL_ttf.a */; };
+		FC047D29151E88A500C5E9E7 /* libfreetype.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D28151E88A500C5E9E7 /* libfreetype.a */; };
+		FC047D2B151E898300C5E9E7 /* libiconv.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D2A151E898300C5E9E7 /* libiconv.a */; };
+		FC047D2D151E89D300C5E9E7 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D2C151E89D200C5E9E7 /* IOKit.framework */; };
+		FC047D2F151E8E9400C5E9E7 /* libintl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D2E151E8E9400C5E9E7 /* libintl.a */; };
+		FC047D31151E8F8200C5E9E7 /* data in Resources */ = {isa = PBXBuildFile; fileRef = FC047D30151E8F8200C5E9E7 /* data */; };
+		FC047D3D151E94B500C5E9E7 /* libguichan_opengl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D3A151E94B500C5E9E7 /* libguichan_opengl.a */; };
+		FC047D3E151E94B500C5E9E7 /* libguichan_sdl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D3B151E94B500C5E9E7 /* libguichan_sdl.a */; };
+		FC047D3F151E94B500C5E9E7 /* libguichan.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC047D3C151E94B500C5E9E7 /* libguichan.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		FC047D32151E920100C5E9E7 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		2FBA050315B8ED49001AB720 /* SDL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL.framework; path = ../../../../../../../../Library/Frameworks/SDL.framework; sourceTree = "<group>"; };
+		2FBA050515B8ED59001AB720 /* SDL_mixer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL_mixer.framework; path = ../../../../../../../../Library/Frameworks/SDL_mixer.framework; sourceTree = "<group>"; };
+		2FBA050715B8ED6D001AB720 /* SDL_image.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL_image.framework; path = ../../../../../../../../Library/Frameworks/SDL_image.framework; sourceTree = "<group>"; };
+		FC0479C6151E4DB700C5E9E7 /* mana.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = mana.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC0479CA151E4DB700C5E9E7 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		FC0479CD151E4DB700C5E9E7 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		FC0479CE151E4DB700C5E9E7 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		FC0479CF151E4DB700C5E9E7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		FC0479D2151E4DB700C5E9E7 /* mana-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "mana-Info.plist"; sourceTree = "<group>"; };
+		FC0479D4151E4DB700C5E9E7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		FC0479E0151E4DB800C5E9E7 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		FC0479E7151E4F8800C5E9E7 /* actor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = actor.cpp; path = ../../src/actor.cpp; sourceTree = "<group>"; };
+		FC0479E8151E4F8800C5E9E7 /* actor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = actor.h; path = ../../src/actor.h; sourceTree = "<group>"; };
+		FC0479E9151E4F8800C5E9E7 /* actorsprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = actorsprite.cpp; path = ../../src/actorsprite.cpp; sourceTree = "<group>"; };
+		FC0479EA151E4F8800C5E9E7 /* actorsprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = actorsprite.h; path = ../../src/actorsprite.h; sourceTree = "<group>"; };
+		FC0479EB151E4F8800C5E9E7 /* actorspritemanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = actorspritemanager.cpp; path = ../../src/actorspritemanager.cpp; sourceTree = "<group>"; };
+		FC0479EC151E4F8800C5E9E7 /* actorspritemanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = actorspritemanager.h; path = ../../src/actorspritemanager.h; sourceTree = "<group>"; };
+		FC0479ED151E4F8800C5E9E7 /* animatedsprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = animatedsprite.cpp; path = ../../src/animatedsprite.cpp; sourceTree = "<group>"; };
+		FC0479EE151E4F8800C5E9E7 /* animatedsprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = animatedsprite.h; path = ../../src/animatedsprite.h; sourceTree = "<group>"; };
+		FC0479EF151E4F8800C5E9E7 /* animationparticle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = animationparticle.cpp; path = ../../src/animationparticle.cpp; sourceTree = "<group>"; };
+		FC0479F0151E4F8800C5E9E7 /* animationparticle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = animationparticle.h; path = ../../src/animationparticle.h; sourceTree = "<group>"; };
+		FC0479F1151E4F8800C5E9E7 /* avatar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = avatar.cpp; path = ../../src/avatar.cpp; sourceTree = "<group>"; };
+		FC0479F2151E4F8800C5E9E7 /* avatar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = avatar.h; path = ../../src/avatar.h; sourceTree = "<group>"; };
+		FC0479F3151E4F8800C5E9E7 /* being.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = being.cpp; path = ../../src/being.cpp; sourceTree = "<group>"; };
+		FC0479F4151E4F8800C5E9E7 /* being.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = being.h; path = ../../src/being.h; sourceTree = "<group>"; };
+		FC0479F5151E4F8800C5E9E7 /* channel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = channel.cpp; path = ../../src/channel.cpp; sourceTree = "<group>"; };
+		FC0479F6151E4F8800C5E9E7 /* channel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = channel.h; path = ../../src/channel.h; sourceTree = "<group>"; };
+		FC0479F7151E4F8800C5E9E7 /* channelmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = channelmanager.cpp; path = ../../src/channelmanager.cpp; sourceTree = "<group>"; };
+		FC0479F8151E4F8800C5E9E7 /* channelmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = channelmanager.h; path = ../../src/channelmanager.h; sourceTree = "<group>"; };
+		FC0479F9151E4F8800C5E9E7 /* chatlogger.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = chatlogger.cpp; path = ../../src/chatlogger.cpp; sourceTree = "<group>"; };
+		FC0479FA151E4F8800C5E9E7 /* chatlogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = chatlogger.h; path = ../../src/chatlogger.h; sourceTree = "<group>"; };
+		FC0479FB151E4F8800C5E9E7 /* client.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = client.cpp; path = ../../src/client.cpp; sourceTree = "<group>"; };
+		FC0479FC151E4F8800C5E9E7 /* client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = client.h; path = ../../src/client.h; sourceTree = "<group>"; };
+		FC0479FD151E4F8800C5E9E7 /* commandhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = commandhandler.cpp; path = ../../src/commandhandler.cpp; sourceTree = "<group>"; };
+		FC0479FE151E4F8800C5E9E7 /* commandhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = commandhandler.h; path = ../../src/commandhandler.h; sourceTree = "<group>"; };
+		FC0479FF151E4F8800C5E9E7 /* compoundsprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = compoundsprite.cpp; path = ../../src/compoundsprite.cpp; sourceTree = "<group>"; };
+		FC047A00151E4F8800C5E9E7 /* compoundsprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = compoundsprite.h; path = ../../src/compoundsprite.h; sourceTree = "<group>"; };
+		FC047A01151E4F8800C5E9E7 /* configuration.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = configuration.cpp; path = ../../src/configuration.cpp; sourceTree = "<group>"; };
+		FC047A02151E4F8800C5E9E7 /* configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = configuration.h; path = ../../src/configuration.h; sourceTree = "<group>"; };
+		FC047A03151E4F8800C5E9E7 /* defaults.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = defaults.cpp; path = ../../src/defaults.cpp; sourceTree = "<group>"; };
+		FC047A04151E4F8800C5E9E7 /* defaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = defaults.h; path = ../../src/defaults.h; sourceTree = "<group>"; };
+		FC047A05151E4F8800C5E9E7 /* effectmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = effectmanager.cpp; path = ../../src/effectmanager.cpp; sourceTree = "<group>"; };
+		FC047A06151E4F8800C5E9E7 /* effectmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = effectmanager.h; path = ../../src/effectmanager.h; sourceTree = "<group>"; };
+		FC047A07151E4F8800C5E9E7 /* emoteshortcut.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = emoteshortcut.cpp; path = ../../src/emoteshortcut.cpp; sourceTree = "<group>"; };
+		FC047A08151E4F8800C5E9E7 /* emoteshortcut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = emoteshortcut.h; path = ../../src/emoteshortcut.h; sourceTree = "<group>"; };
+		FC047A09151E4F8800C5E9E7 /* equipment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = equipment.h; path = ../../src/equipment.h; sourceTree = "<group>"; };
+		FC047A0A151E4F8800C5E9E7 /* event.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = event.cpp; path = ../../src/event.cpp; sourceTree = "<group>"; };
+		FC047A0B151E4F8800C5E9E7 /* event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = event.h; path = ../../src/event.h; sourceTree = "<group>"; };
+		FC047A0C151E4F8800C5E9E7 /* eventlistener.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = eventlistener.cpp; path = ../../src/eventlistener.cpp; sourceTree = "<group>"; };
+		FC047A0D151E4F8800C5E9E7 /* eventlistener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = eventlistener.h; path = ../../src/eventlistener.h; sourceTree = "<group>"; };
+		FC047A0E151E4F8800C5E9E7 /* flooritem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = flooritem.cpp; path = ../../src/flooritem.cpp; sourceTree = "<group>"; };
+		FC047A0F151E4F8800C5E9E7 /* flooritem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = flooritem.h; path = ../../src/flooritem.h; sourceTree = "<group>"; };
+		FC047A10151E4F8800C5E9E7 /* game.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = game.cpp; path = ../../src/game.cpp; sourceTree = "<group>"; };
+		FC047A11151E4F8800C5E9E7 /* game.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = game.h; path = ../../src/game.h; sourceTree = "<group>"; };
+		FC047A12151E4F8800C5E9E7 /* graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = graphics.cpp; path = ../../src/graphics.cpp; sourceTree = "<group>"; };
+		FC047A29151E4FC700C5E9E7 /* graphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = graphics.h; path = ../../src/graphics.h; sourceTree = "<group>"; };
+		FC047A2A151E4FC700C5E9E7 /* guichanfwd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = guichanfwd.h; path = ../../src/guichanfwd.h; sourceTree = "<group>"; };
+		FC047A2B151E4FC700C5E9E7 /* guild.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = guild.cpp; path = ../../src/guild.cpp; sourceTree = "<group>"; };
+		FC047A2C151E4FC700C5E9E7 /* guild.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = guild.h; path = ../../src/guild.h; sourceTree = "<group>"; };
+		FC047A2D151E4FC700C5E9E7 /* imageparticle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = imageparticle.cpp; path = ../../src/imageparticle.cpp; sourceTree = "<group>"; };
+		FC047A2E151E4FC700C5E9E7 /* imageparticle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imageparticle.h; path = ../../src/imageparticle.h; sourceTree = "<group>"; };
+		FC047A2F151E4FC700C5E9E7 /* imagesprite.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = imagesprite.cpp; path = ../../src/imagesprite.cpp; sourceTree = "<group>"; };
+		FC047A30151E4FC700C5E9E7 /* imagesprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = imagesprite.h; path = ../../src/imagesprite.h; sourceTree = "<group>"; };
+		FC047A31151E4FC700C5E9E7 /* inventory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = inventory.cpp; path = ../../src/inventory.cpp; sourceTree = "<group>"; };
+		FC047A32151E4FC700C5E9E7 /* inventory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = inventory.h; path = ../../src/inventory.h; sourceTree = "<group>"; };
+		FC047A33151E4FC700C5E9E7 /* item.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = item.cpp; path = ../../src/item.cpp; sourceTree = "<group>"; };
+		FC047A34151E4FC700C5E9E7 /* item.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = item.h; path = ../../src/item.h; sourceTree = "<group>"; };
+		FC047A35151E4FC700C5E9E7 /* itemshortcut.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = itemshortcut.cpp; path = ../../src/itemshortcut.cpp; sourceTree = "<group>"; };
+		FC047A36151E4FC700C5E9E7 /* itemshortcut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = itemshortcut.h; path = ../../src/itemshortcut.h; sourceTree = "<group>"; };
+		FC047A37151E4FC700C5E9E7 /* joystick.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = joystick.cpp; path = ../../src/joystick.cpp; sourceTree = "<group>"; };
+		FC047A38151E4FC700C5E9E7 /* joystick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = joystick.h; path = ../../src/joystick.h; sourceTree = "<group>"; };
+		FC047A39151E4FC700C5E9E7 /* keyboardconfig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = keyboardconfig.cpp; path = ../../src/keyboardconfig.cpp; sourceTree = "<group>"; };
+		FC047A3A151E4FC700C5E9E7 /* keyboardconfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = keyboardconfig.h; path = ../../src/keyboardconfig.h; sourceTree = "<group>"; };
+		FC047A3B151E4FC700C5E9E7 /* localplayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = localplayer.cpp; path = ../../src/localplayer.cpp; sourceTree = "<group>"; };
+		FC047A3C151E4FC700C5E9E7 /* localplayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = localplayer.h; path = ../../src/localplayer.h; sourceTree = "<group>"; };
+		FC047A3D151E4FC700C5E9E7 /* log.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = log.cpp; path = ../../src/log.cpp; sourceTree = "<group>"; };
+		FC047A3E151E4FC700C5E9E7 /* log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = log.h; path = ../../src/log.h; sourceTree = "<group>"; };
+		FC047A3F151E4FC700C5E9E7 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = main.cpp; path = ../../src/main.cpp; sourceTree = "<group>"; };
+		FC047A40151E4FC700C5E9E7 /* main.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = main.h; path = ../../src/main.h; sourceTree = "<group>"; };
+		FC047A41151E4FC700C5E9E7 /* map.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = map.cpp; path = ../../src/map.cpp; sourceTree = "<group>"; };
+		FC047A42151E4FC700C5E9E7 /* map.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = map.h; path = ../../src/map.h; sourceTree = "<group>"; };
+		FC047A43151E4FC700C5E9E7 /* openglgraphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = openglgraphics.cpp; path = ../../src/openglgraphics.cpp; sourceTree = "<group>"; };
+		FC047A44151E4FC700C5E9E7 /* openglgraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = openglgraphics.h; path = ../../src/openglgraphics.h; sourceTree = "<group>"; };
+		FC047A45151E4FC700C5E9E7 /* particle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = particle.cpp; path = ../../src/particle.cpp; sourceTree = "<group>"; };
+		FC047A46151E4FC700C5E9E7 /* particle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = particle.h; path = ../../src/particle.h; sourceTree = "<group>"; };
+		FC047A47151E4FC700C5E9E7 /* particlecontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = particlecontainer.cpp; path = ../../src/particlecontainer.cpp; sourceTree = "<group>"; };
+		FC047A48151E4FC700C5E9E7 /* particlecontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = particlecontainer.h; path = ../../src/particlecontainer.h; sourceTree = "<group>"; };
+		FC047A49151E4FC700C5E9E7 /* particleemitter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = particleemitter.cpp; path = ../../src/particleemitter.cpp; sourceTree = "<group>"; };
+		FC047A4A151E4FC700C5E9E7 /* particleemitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = particleemitter.h; path = ../../src/particleemitter.h; sourceTree = "<group>"; };
+		FC047A4B151E4FC700C5E9E7 /* particleemitterprop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = particleemitterprop.h; path = ../../src/particleemitterprop.h; sourceTree = "<group>"; };
+		FC047A4C151E4FC700C5E9E7 /* party.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = party.cpp; path = ../../src/party.cpp; sourceTree = "<group>"; };
+		FC047A4D151E4FC700C5E9E7 /* party.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = party.h; path = ../../src/party.h; sourceTree = "<group>"; };
+		FC047A4E151E4FC700C5E9E7 /* playerinfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = playerinfo.cpp; path = ../../src/playerinfo.cpp; sourceTree = "<group>"; };
+		FC047A4F151E4FC700C5E9E7 /* playerinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = playerinfo.h; path = ../../src/playerinfo.h; sourceTree = "<group>"; };
+		FC047A50151E4FC700C5E9E7 /* playerrelations.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = playerrelations.cpp; path = ../../src/playerrelations.cpp; sourceTree = "<group>"; };
+		FC047A51151E4FC700C5E9E7 /* playerrelations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = playerrelations.h; path = ../../src/playerrelations.h; sourceTree = "<group>"; };
+		FC047A52151E4FC700C5E9E7 /* position.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = position.cpp; path = ../../src/position.cpp; sourceTree = "<group>"; };
+		FC047A53151E4FC700C5E9E7 /* position.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = position.h; path = ../../src/position.h; sourceTree = "<group>"; };
+		FC047A54151E4FC700C5E9E7 /* properties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = properties.h; path = ../../src/properties.h; sourceTree = "<group>"; };
+		FC047A55151E4FC700C5E9E7 /* rotationalparticle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rotationalparticle.cpp; path = ../../src/rotationalparticle.cpp; sourceTree = "<group>"; };
+		FC047A56151E4FC700C5E9E7 /* rotationalparticle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = rotationalparticle.h; path = ../../src/rotationalparticle.h; sourceTree = "<group>"; };
+		FC047A57151E4FC700C5E9E7 /* SDLMain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDLMain.h; path = ../../src/SDLMain.h; sourceTree = "<group>"; };
+		FC047A58151E4FC700C5E9E7 /* SDLMain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDLMain.m; path = ../../src/SDLMain.m; sourceTree = "<group>"; };
+		FC047A59151E4FC700C5E9E7 /* shopitem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = shopitem.cpp; path = ../../src/shopitem.cpp; sourceTree = "<group>"; };
+		FC047A5A151E4FC700C5E9E7 /* shopitem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = shopitem.h; path = ../../src/shopitem.h; sourceTree = "<group>"; };
+		FC047A5B151E4FC700C5E9E7 /* simpleanimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = simpleanimation.cpp; path = ../../src/simpleanimation.cpp; sourceTree = "<group>"; };
+		FC047A5C151E4FC700C5E9E7 /* simpleanimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = simpleanimation.h; path = ../../src/simpleanimation.h; sourceTree = "<group>"; };
+		FC047A5D151E4FC700C5E9E7 /* sound.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sound.cpp; path = ../../src/sound.cpp; sourceTree = "<group>"; };
+		FC047A5E151E4FC700C5E9E7 /* sound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sound.h; path = ../../src/sound.h; sourceTree = "<group>"; };
+		FC047A5F151E4FC700C5E9E7 /* sprite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sprite.h; path = ../../src/sprite.h; sourceTree = "<group>"; };
+		FC047A60151E4FC700C5E9E7 /* statuseffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = statuseffect.cpp; path = ../../src/statuseffect.cpp; sourceTree = "<group>"; };
+		FC047A61151E4FC700C5E9E7 /* statuseffect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = statuseffect.h; path = ../../src/statuseffect.h; sourceTree = "<group>"; };
+		FC047A62151E4FC700C5E9E7 /* text.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = text.cpp; path = ../../src/text.cpp; sourceTree = "<group>"; };
+		FC047A63151E4FC700C5E9E7 /* text.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = text.h; path = ../../src/text.h; sourceTree = "<group>"; };
+		FC047A64151E4FC700C5E9E7 /* textmanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = textmanager.cpp; path = ../../src/textmanager.cpp; sourceTree = "<group>"; };
+		FC047A65151E4FC700C5E9E7 /* textmanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = textmanager.h; path = ../../src/textmanager.h; sourceTree = "<group>"; };
+		FC047A66151E4FC700C5E9E7 /* textparticle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = textparticle.cpp; path = ../../src/textparticle.cpp; sourceTree = "<group>"; };
+		FC047A67151E4FC700C5E9E7 /* textparticle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = textparticle.h; path = ../../src/textparticle.h; sourceTree = "<group>"; };
+		FC047A68151E4FC700C5E9E7 /* textrenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = textrenderer.h; path = ../../src/textrenderer.h; sourceTree = "<group>"; };
+		FC047A69151E4FC700C5E9E7 /* tileset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = tileset.h; path = ../../src/tileset.h; sourceTree = "<group>"; };
+		FC047A6A151E4FC700C5E9E7 /* units.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = units.cpp; path = ../../src/units.cpp; sourceTree = "<group>"; };
+		FC047A6B151E4FC700C5E9E7 /* units.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = units.h; path = ../../src/units.h; sourceTree = "<group>"; };
+		FC047A6C151E4FC700C5E9E7 /* variabledata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = variabledata.h; path = ../../src/variabledata.h; sourceTree = "<group>"; };
+		FC047A6D151E4FC700C5E9E7 /* vector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = vector.cpp; path = ../../src/vector.cpp; sourceTree = "<group>"; };
+		FC047A6E151E4FC700C5E9E7 /* vector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = vector.h; path = ../../src/vector.h; sourceTree = "<group>"; };
+		FC047A8F151E4FF700C5E9E7 /* beingpopup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = beingpopup.cpp; sourceTree = "<group>"; };
+		FC047A90151E4FF700C5E9E7 /* beingpopup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = beingpopup.h; sourceTree = "<group>"; };
+		FC047A91151E4FF700C5E9E7 /* buydialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = buydialog.cpp; sourceTree = "<group>"; };
+		FC047A92151E4FF700C5E9E7 /* buydialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buydialog.h; sourceTree = "<group>"; };
+		FC047A93151E4FF700C5E9E7 /* buyselldialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = buyselldialog.cpp; sourceTree = "<group>"; };
+		FC047A94151E4FF700C5E9E7 /* buyselldialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buyselldialog.h; sourceTree = "<group>"; };
+		FC047A95151E4FF700C5E9E7 /* changeemaildialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = changeemaildialog.cpp; sourceTree = "<group>"; };
+		FC047A96151E4FF700C5E9E7 /* changeemaildialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = changeemaildialog.h; sourceTree = "<group>"; };
+		FC047A97151E4FF700C5E9E7 /* changepassworddialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = changepassworddialog.cpp; sourceTree = "<group>"; };
+		FC047A98151E4FF700C5E9E7 /* changepassworddialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = changepassworddialog.h; sourceTree = "<group>"; };
+		FC047A99151E4FF700C5E9E7 /* charcreatedialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = charcreatedialog.cpp; sourceTree = "<group>"; };
+		FC047A9A151E4FF700C5E9E7 /* charcreatedialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = charcreatedialog.h; sourceTree = "<group>"; };
+		FC047A9B151E4FF700C5E9E7 /* charselectdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = charselectdialog.cpp; sourceTree = "<group>"; };
+		FC047A9C151E4FF700C5E9E7 /* charselectdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = charselectdialog.h; sourceTree = "<group>"; };
+		FC047A9D151E4FF700C5E9E7 /* chatwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = chatwindow.cpp; sourceTree = "<group>"; };
+		FC047A9E151E4FF700C5E9E7 /* chatwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chatwindow.h; sourceTree = "<group>"; };
+		FC047A9F151E4FF700C5E9E7 /* confirmdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = confirmdialog.cpp; sourceTree = "<group>"; };
+		FC047AA0151E4FF700C5E9E7 /* confirmdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = confirmdialog.h; sourceTree = "<group>"; };
+		FC047AA1151E4FF700C5E9E7 /* connectiondialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = connectiondialog.cpp; sourceTree = "<group>"; };
+		FC047AA2151E4FF700C5E9E7 /* connectiondialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = connectiondialog.h; sourceTree = "<group>"; };
+		FC047AA3151E4FF700C5E9E7 /* customserverdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = customserverdialog.cpp; sourceTree = "<group>"; };
+		FC047AA4151E4FF700C5E9E7 /* customserverdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = customserverdialog.h; sourceTree = "<group>"; };
+		FC047AA5151E4FF700C5E9E7 /* debugwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = debugwindow.cpp; sourceTree = "<group>"; };
+		FC047AA6151E4FF700C5E9E7 /* debugwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debugwindow.h; sourceTree = "<group>"; };
+		FC047AA7151E4FF700C5E9E7 /* emotepopup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = emotepopup.cpp; sourceTree = "<group>"; };
+		FC047AA8151E4FF700C5E9E7 /* emotepopup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = emotepopup.h; sourceTree = "<group>"; };
+		FC047AA9151E4FF700C5E9E7 /* equipmentwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = equipmentwindow.cpp; sourceTree = "<group>"; };
+		FC047AAA151E4FF700C5E9E7 /* equipmentwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = equipmentwindow.h; sourceTree = "<group>"; };
+		FC047AAB151E4FF700C5E9E7 /* focushandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = focushandler.cpp; sourceTree = "<group>"; };
+		FC047AAC151E4FF700C5E9E7 /* focushandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = focushandler.h; sourceTree = "<group>"; };
+		FC047AAD151E4FF700C5E9E7 /* gui.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gui.cpp; sourceTree = "<group>"; };
+		FC047AAE151E4FF700C5E9E7 /* gui.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gui.h; sourceTree = "<group>"; };
+		FC047AAF151E4FF700C5E9E7 /* helpwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = helpwindow.cpp; sourceTree = "<group>"; };
+		FC047AB0151E4FF700C5E9E7 /* helpwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = helpwindow.h; sourceTree = "<group>"; };
+		FC047AB1151E4FF700C5E9E7 /* inventorywindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inventorywindow.cpp; sourceTree = "<group>"; };
+		FC047AB2151E4FF700C5E9E7 /* inventorywindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inventorywindow.h; sourceTree = "<group>"; };
+		FC047AB3151E4FF700C5E9E7 /* itemamountwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itemamountwindow.cpp; sourceTree = "<group>"; };
+		FC047AB4151E4FF700C5E9E7 /* itemamountwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itemamountwindow.h; sourceTree = "<group>"; };
+		FC047AB5151E4FF700C5E9E7 /* itempopup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itempopup.cpp; sourceTree = "<group>"; };
+		FC047AB6151E4FF700C5E9E7 /* itempopup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itempopup.h; sourceTree = "<group>"; };
+		FC047AB7151E4FF700C5E9E7 /* logindialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = logindialog.cpp; sourceTree = "<group>"; };
+		FC047AB8151E4FF700C5E9E7 /* logindialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logindialog.h; sourceTree = "<group>"; };
+		FC047AB9151E4FF700C5E9E7 /* minimap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = minimap.cpp; sourceTree = "<group>"; };
+		FC047ABA151E4FF700C5E9E7 /* minimap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = minimap.h; sourceTree = "<group>"; };
+		FC047ABB151E4FF700C5E9E7 /* ministatuswindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ministatuswindow.cpp; sourceTree = "<group>"; };
+		FC047ABC151E4FF700C5E9E7 /* ministatuswindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ministatuswindow.h; sourceTree = "<group>"; };
+		FC047ABD151E4FF700C5E9E7 /* npcdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = npcdialog.cpp; sourceTree = "<group>"; };
+		FC047ABE151E4FF700C5E9E7 /* npcdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = npcdialog.h; sourceTree = "<group>"; };
+		FC047ABF151E4FF700C5E9E7 /* npcpostdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = npcpostdialog.cpp; sourceTree = "<group>"; };
+		FC047AC0151E4FF700C5E9E7 /* npcpostdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = npcpostdialog.h; sourceTree = "<group>"; };
+		FC047AC1151E4FF700C5E9E7 /* okdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = okdialog.cpp; sourceTree = "<group>"; };
+		FC047AC2151E4FF700C5E9E7 /* okdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = okdialog.h; sourceTree = "<group>"; };
+		FC047AC3151E4FF700C5E9E7 /* outfitwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = outfitwindow.cpp; sourceTree = "<group>"; };
+		FC047AC4151E4FF700C5E9E7 /* outfitwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = outfitwindow.h; sourceTree = "<group>"; };
+		FC047AC5151E4FF700C5E9E7 /* palette.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = palette.cpp; sourceTree = "<group>"; };
+		FC047AC6151E4FF700C5E9E7 /* palette.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = palette.h; sourceTree = "<group>"; };
+		FC047AC7151E4FF700C5E9E7 /* popupmenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = popupmenu.cpp; sourceTree = "<group>"; };
+		FC047AC8151E4FF700C5E9E7 /* popupmenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = popupmenu.h; sourceTree = "<group>"; };
+		FC047AC9151E4FF700C5E9E7 /* quitdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = quitdialog.cpp; sourceTree = "<group>"; };
+		FC047ACA151E4FF700C5E9E7 /* quitdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quitdialog.h; sourceTree = "<group>"; };
+		FC047ACB151E4FF700C5E9E7 /* recorder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = recorder.cpp; sourceTree = "<group>"; };
+		FC047ACC151E4FF700C5E9E7 /* recorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = recorder.h; sourceTree = "<group>"; };
+		FC047ACD151E4FF700C5E9E7 /* register.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = register.cpp; sourceTree = "<group>"; };
+		FC047ACE151E4FF700C5E9E7 /* register.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = register.h; sourceTree = "<group>"; };
+		FC047ACF151E4FF700C5E9E7 /* sdlinput.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sdlinput.cpp; sourceTree = "<group>"; };
+		FC047AD0151E4FF700C5E9E7 /* sdlinput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sdlinput.h; sourceTree = "<group>"; };
+		FC047AD1151E4FF700C5E9E7 /* selldialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = selldialog.cpp; sourceTree = "<group>"; };
+		FC047AD2151E4FF700C5E9E7 /* selldialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = selldialog.h; sourceTree = "<group>"; };
+		FC047AD3151E4FF700C5E9E7 /* serverdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = serverdialog.cpp; sourceTree = "<group>"; };
+		FC047AD4151E4FF700C5E9E7 /* serverdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serverdialog.h; sourceTree = "<group>"; };
+		FC047AD5151E4FF700C5E9E7 /* setup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup.cpp; sourceTree = "<group>"; };
+		FC047AD6151E4FF700C5E9E7 /* setup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup.h; sourceTree = "<group>"; };
+		FC047AD7151E4FF700C5E9E7 /* setup_audio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup_audio.cpp; sourceTree = "<group>"; };
+		FC047AD8151E4FF700C5E9E7 /* setup_audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup_audio.h; sourceTree = "<group>"; };
+		FC047AD9151E4FF700C5E9E7 /* setup_colors.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup_colors.cpp; sourceTree = "<group>"; };
+		FC047ADA151E4FF700C5E9E7 /* setup_colors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup_colors.h; sourceTree = "<group>"; };
+		FC047ADB151E4FF700C5E9E7 /* setup_interface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup_interface.cpp; sourceTree = "<group>"; };
+		FC047ADC151E4FF700C5E9E7 /* setup_interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup_interface.h; sourceTree = "<group>"; };
+		FC047ADD151E4FF700C5E9E7 /* setup_joystick.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup_joystick.cpp; sourceTree = "<group>"; };
+		FC047ADE151E4FF700C5E9E7 /* setup_joystick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup_joystick.h; sourceTree = "<group>"; };
+		FC047ADF151E4FF700C5E9E7 /* setup_keyboard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup_keyboard.cpp; sourceTree = "<group>"; };
+		FC047AE0151E4FF700C5E9E7 /* setup_keyboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup_keyboard.h; sourceTree = "<group>"; };
+		FC047AE1151E4FF700C5E9E7 /* setup_players.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup_players.cpp; sourceTree = "<group>"; };
+		FC047AE2151E4FF700C5E9E7 /* setup_players.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup_players.h; sourceTree = "<group>"; };
+		FC047AE3151E4FF700C5E9E7 /* setup_video.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setup_video.cpp; sourceTree = "<group>"; };
+		FC047AE4151E4FF700C5E9E7 /* setup_video.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setup_video.h; sourceTree = "<group>"; };
+		FC047AE5151E4FF700C5E9E7 /* shortcutwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = shortcutwindow.cpp; sourceTree = "<group>"; };
+		FC047AE6151E4FF700C5E9E7 /* shortcutwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shortcutwindow.h; sourceTree = "<group>"; };
+		FC047AE7151E4FF700C5E9E7 /* skilldialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = skilldialog.cpp; sourceTree = "<group>"; };
+		FC047AE8151E4FF700C5E9E7 /* skilldialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = skilldialog.h; sourceTree = "<group>"; };
+		FC047AE9151E4FF700C5E9E7 /* socialwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = socialwindow.cpp; sourceTree = "<group>"; };
+		FC047AEA151E4FF700C5E9E7 /* socialwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socialwindow.h; sourceTree = "<group>"; };
+		FC047AEB151E4FF700C5E9E7 /* specialswindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = specialswindow.cpp; sourceTree = "<group>"; };
+		FC047AEC151E4FF700C5E9E7 /* specialswindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = specialswindow.h; sourceTree = "<group>"; };
+		FC047AED151E4FF700C5E9E7 /* speechbubble.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = speechbubble.cpp; sourceTree = "<group>"; };
+		FC047AEE151E4FF700C5E9E7 /* speechbubble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = speechbubble.h; sourceTree = "<group>"; };
+		FC047AEF151E4FF700C5E9E7 /* statuswindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = statuswindow.cpp; sourceTree = "<group>"; };
+		FC047AF0151E4FF700C5E9E7 /* statuswindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = statuswindow.h; sourceTree = "<group>"; };
+		FC047AF1151E4FF700C5E9E7 /* textdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = textdialog.cpp; sourceTree = "<group>"; };
+		FC047AF2151E4FF700C5E9E7 /* textdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = textdialog.h; sourceTree = "<group>"; };
+		FC047AF3151E4FF700C5E9E7 /* textpopup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = textpopup.cpp; sourceTree = "<group>"; };
+		FC047AF4151E4FF700C5E9E7 /* textpopup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = textpopup.h; sourceTree = "<group>"; };
+		FC047AF5151E4FF700C5E9E7 /* tradewindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tradewindow.cpp; sourceTree = "<group>"; };
+		FC047AF6151E4FF700C5E9E7 /* tradewindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tradewindow.h; sourceTree = "<group>"; };
+		FC047AF7151E4FF700C5E9E7 /* truetypefont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = truetypefont.cpp; sourceTree = "<group>"; };
+		FC047AF8151E4FF700C5E9E7 /* truetypefont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = truetypefont.h; sourceTree = "<group>"; };
+		FC047AF9151E4FF700C5E9E7 /* unregisterdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unregisterdialog.cpp; sourceTree = "<group>"; };
+		FC047AFA151E4FF700C5E9E7 /* unregisterdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unregisterdialog.h; sourceTree = "<group>"; };
+		FC047AFB151E4FF700C5E9E7 /* updaterwindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = updaterwindow.cpp; sourceTree = "<group>"; };
+		FC047AFC151E4FF700C5E9E7 /* updaterwindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = updaterwindow.h; sourceTree = "<group>"; };
+		FC047AFD151E4FF700C5E9E7 /* viewport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = viewport.cpp; sourceTree = "<group>"; };
+		FC047AFE151E4FF700C5E9E7 /* viewport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = viewport.h; sourceTree = "<group>"; };
+		FC047B00151E4FF700C5E9E7 /* avatarlistbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = avatarlistbox.cpp; sourceTree = "<group>"; };
+		FC047B01151E4FF700C5E9E7 /* avatarlistbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = avatarlistbox.h; sourceTree = "<group>"; };
+		FC047B02151E4FF700C5E9E7 /* browserbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = browserbox.cpp; sourceTree = "<group>"; };
+		FC047B03151E4FF700C5E9E7 /* browserbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = browserbox.h; sourceTree = "<group>"; };
+		FC047B04151E4FF700C5E9E7 /* button.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = button.cpp; sourceTree = "<group>"; };
+		FC047B05151E4FF700C5E9E7 /* button.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = button.h; sourceTree = "<group>"; };
+		FC047B06151E4FF700C5E9E7 /* channeltab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = channeltab.cpp; sourceTree = "<group>"; };
+		FC047B07151E4FF700C5E9E7 /* channeltab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = channeltab.h; sourceTree = "<group>"; };
+		FC047B08151E4FF700C5E9E7 /* chattab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = chattab.cpp; sourceTree = "<group>"; };
+		FC047B09151E4FF700C5E9E7 /* chattab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chattab.h; sourceTree = "<group>"; };
+		FC047B0A151E4FF700C5E9E7 /* checkbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checkbox.cpp; sourceTree = "<group>"; };
+		FC047B0B151E4FF700C5E9E7 /* checkbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = checkbox.h; sourceTree = "<group>"; };
+		FC047B0C151E4FF700C5E9E7 /* container.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = container.cpp; sourceTree = "<group>"; };
+		FC047B0D151E4FF700C5E9E7 /* container.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = container.h; sourceTree = "<group>"; };
+		FC047B0E151E4FF700C5E9E7 /* desktop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = desktop.cpp; sourceTree = "<group>"; };
+		FC047B0F151E4FF700C5E9E7 /* desktop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = desktop.h; sourceTree = "<group>"; };
+		FC047B10151E4FF700C5E9E7 /* dropdown.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dropdown.cpp; sourceTree = "<group>"; };
+		FC047B11151E4FF700C5E9E7 /* dropdown.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dropdown.h; sourceTree = "<group>"; };
+		FC047B12151E4FF700C5E9E7 /* emoteshortcutcontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = emoteshortcutcontainer.cpp; sourceTree = "<group>"; };
+		FC047B13151E4FF700C5E9E7 /* emoteshortcutcontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = emoteshortcutcontainer.h; sourceTree = "<group>"; };
+		FC047B14151E4FF700C5E9E7 /* flowcontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = flowcontainer.cpp; sourceTree = "<group>"; };
+		FC047B15151E4FF700C5E9E7 /* flowcontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flowcontainer.h; sourceTree = "<group>"; };
+		FC047B16151E4FF700C5E9E7 /* icon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = icon.cpp; sourceTree = "<group>"; };
+		FC047B17151E4FF700C5E9E7 /* icon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = icon.h; sourceTree = "<group>"; };
+		FC047B18151E4FF700C5E9E7 /* inttextfield.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inttextfield.cpp; sourceTree = "<group>"; };
+		FC047B19151E4FF700C5E9E7 /* inttextfield.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inttextfield.h; sourceTree = "<group>"; };
+		FC047B1A151E4FF700C5E9E7 /* itemcontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itemcontainer.cpp; sourceTree = "<group>"; };
+		FC047B1B151E4FF700C5E9E7 /* itemcontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itemcontainer.h; sourceTree = "<group>"; };
+		FC047B1C151E4FF700C5E9E7 /* itemlinkhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itemlinkhandler.cpp; sourceTree = "<group>"; };
+		FC047B1D151E4FF700C5E9E7 /* itemlinkhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itemlinkhandler.h; sourceTree = "<group>"; };
+		FC047B1E151E4FF700C5E9E7 /* itemshortcutcontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itemshortcutcontainer.cpp; sourceTree = "<group>"; };
+		FC047B1F151E4FF700C5E9E7 /* itemshortcutcontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itemshortcutcontainer.h; sourceTree = "<group>"; };
+		FC047B20151E4FF700C5E9E7 /* label.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = label.cpp; sourceTree = "<group>"; };
+		FC047B21151E4FF700C5E9E7 /* label.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = label.h; sourceTree = "<group>"; };
+		FC047B22151E4FF700C5E9E7 /* layout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = layout.cpp; sourceTree = "<group>"; };
+		FC047B23151E4FF700C5E9E7 /* layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = layout.h; sourceTree = "<group>"; };
+		FC047B24151E4FF700C5E9E7 /* layouthelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = layouthelper.cpp; sourceTree = "<group>"; };
+		FC047B25151E4FF700C5E9E7 /* layouthelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = layouthelper.h; sourceTree = "<group>"; };
+		FC047B26151E4FF700C5E9E7 /* linkhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = linkhandler.h; sourceTree = "<group>"; };
+		FC047B27151E4FF700C5E9E7 /* listbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = listbox.cpp; sourceTree = "<group>"; };
+		FC047B28151E4FF700C5E9E7 /* listbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = listbox.h; sourceTree = "<group>"; };
+		FC047B29151E4FF700C5E9E7 /* passwordfield.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = passwordfield.cpp; sourceTree = "<group>"; };
+		FC047B2A151E4FF700C5E9E7 /* passwordfield.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = passwordfield.h; sourceTree = "<group>"; };
+		FC047B2B151E4FF700C5E9E7 /* playerbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = playerbox.cpp; sourceTree = "<group>"; };
+		FC047B2C151E4FF700C5E9E7 /* playerbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = playerbox.h; sourceTree = "<group>"; };
+		FC047B2D151E4FF700C5E9E7 /* popup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = popup.cpp; sourceTree = "<group>"; };
+		FC047B2E151E4FF700C5E9E7 /* popup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = popup.h; sourceTree = "<group>"; };
+		FC047B2F151E4FF700C5E9E7 /* progressbar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = progressbar.cpp; sourceTree = "<group>"; };
+		FC047B30151E4FF700C5E9E7 /* progressbar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = progressbar.h; sourceTree = "<group>"; };
+		FC047B31151E4FF700C5E9E7 /* progressindicator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = progressindicator.cpp; sourceTree = "<group>"; };
+		FC047B32151E4FF700C5E9E7 /* progressindicator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = progressindicator.h; sourceTree = "<group>"; };
+		FC047B33151E4FF700C5E9E7 /* radiobutton.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = radiobutton.cpp; sourceTree = "<group>"; };
+		FC047B34151E4FF700C5E9E7 /* radiobutton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = radiobutton.h; sourceTree = "<group>"; };
+		FC047B35151E4FF700C5E9E7 /* resizegrip.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resizegrip.cpp; sourceTree = "<group>"; };
+		FC047B36151E4FF700C5E9E7 /* resizegrip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resizegrip.h; sourceTree = "<group>"; };
+		FC047B37151E4FF700C5E9E7 /* scrollarea.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = scrollarea.cpp; sourceTree = "<group>"; };
+		FC047B38151E4FF700C5E9E7 /* scrollarea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scrollarea.h; sourceTree = "<group>"; };
+		FC047B39151E4FF700C5E9E7 /* setuptab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = setuptab.cpp; sourceTree = "<group>"; };
+		FC047B3A151E4FF700C5E9E7 /* setuptab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = setuptab.h; sourceTree = "<group>"; };
+		FC047B3B151E4FF700C5E9E7 /* shopitems.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = shopitems.cpp; sourceTree = "<group>"; };
+		FC047B3C151E4FF700C5E9E7 /* shopitems.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shopitems.h; sourceTree = "<group>"; };
+		FC047B3D151E4FF700C5E9E7 /* shoplistbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = shoplistbox.cpp; sourceTree = "<group>"; };
+		FC047B3E151E4FF700C5E9E7 /* shoplistbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shoplistbox.h; sourceTree = "<group>"; };
+		FC047B3F151E4FF700C5E9E7 /* shortcutcontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = shortcutcontainer.cpp; sourceTree = "<group>"; };
+		FC047B40151E4FF700C5E9E7 /* shortcutcontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = shortcutcontainer.h; sourceTree = "<group>"; };
+		FC047B41151E4FF700C5E9E7 /* slider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = slider.cpp; sourceTree = "<group>"; };
+		FC047B42151E4FF700C5E9E7 /* slider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = slider.h; sourceTree = "<group>"; };
+		FC047B43151E4FF700C5E9E7 /* spacer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spacer.cpp; sourceTree = "<group>"; };
+		FC047B44151E4FF700C5E9E7 /* spacer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spacer.h; sourceTree = "<group>"; };
+		FC047B45151E4FF700C5E9E7 /* tab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tab.cpp; sourceTree = "<group>"; };
+		FC047B46151E4FF700C5E9E7 /* tab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tab.h; sourceTree = "<group>"; };
+		FC047B47151E4FF700C5E9E7 /* tabbedarea.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tabbedarea.cpp; sourceTree = "<group>"; };
+		FC047B48151E4FF700C5E9E7 /* tabbedarea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tabbedarea.h; sourceTree = "<group>"; };
+		FC047B49151E4FF700C5E9E7 /* table.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = table.cpp; sourceTree = "<group>"; };
+		FC047B4A151E4FF700C5E9E7 /* table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = table.h; sourceTree = "<group>"; };
+		FC047B4B151E4FF700C5E9E7 /* tablemodel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tablemodel.cpp; sourceTree = "<group>"; };
+		FC047B4C151E4FF700C5E9E7 /* tablemodel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tablemodel.h; sourceTree = "<group>"; };
+		FC047B4D151E4FF700C5E9E7 /* textbox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = textbox.cpp; sourceTree = "<group>"; };
+		FC047B4E151E4FF700C5E9E7 /* textbox.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = textbox.h; sourceTree = "<group>"; };
+		FC047B4F151E4FF700C5E9E7 /* textfield.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = textfield.cpp; sourceTree = "<group>"; };
+		FC047B50151E4FF700C5E9E7 /* textfield.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = textfield.h; sourceTree = "<group>"; };
+		FC047B51151E4FF700C5E9E7 /* textpreview.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = textpreview.cpp; sourceTree = "<group>"; };
+		FC047B52151E4FF700C5E9E7 /* textpreview.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = textpreview.h; sourceTree = "<group>"; };
+		FC047B53151E4FF700C5E9E7 /* vertcontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = vertcontainer.cpp; sourceTree = "<group>"; };
+		FC047B54151E4FF700C5E9E7 /* vertcontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vertcontainer.h; sourceTree = "<group>"; };
+		FC047B55151E4FF700C5E9E7 /* whispertab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = whispertab.cpp; sourceTree = "<group>"; };
+		FC047B56151E4FF700C5E9E7 /* whispertab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = whispertab.h; sourceTree = "<group>"; };
+		FC047B57151E4FF700C5E9E7 /* window.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = window.cpp; sourceTree = "<group>"; };
+		FC047B58151E4FF700C5E9E7 /* window.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = window.h; sourceTree = "<group>"; };
+		FC047B59151E4FF700C5E9E7 /* windowcontainer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = windowcontainer.cpp; sourceTree = "<group>"; };
+		FC047B5A151E4FF700C5E9E7 /* windowcontainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = windowcontainer.h; sourceTree = "<group>"; };
+		FC047B5B151E4FF700C5E9E7 /* windowmenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = windowmenu.cpp; sourceTree = "<group>"; };
+		FC047B5C151E4FF700C5E9E7 /* windowmenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = windowmenu.h; sourceTree = "<group>"; };
+		FC047B5D151E4FF700C5E9E7 /* worldselectdialog.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = worldselectdialog.cpp; sourceTree = "<group>"; };
+		FC047B5E151E4FF700C5E9E7 /* worldselectdialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = worldselectdialog.h; sourceTree = "<group>"; };
+		FC047BC7151E500100C5E9E7 /* adminhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adminhandler.h; sourceTree = "<group>"; };
+		FC047BC8151E500100C5E9E7 /* charhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = charhandler.cpp; sourceTree = "<group>"; };
+		FC047BC9151E500100C5E9E7 /* charhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = charhandler.h; sourceTree = "<group>"; };
+		FC047BCA151E500100C5E9E7 /* chathandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chathandler.h; sourceTree = "<group>"; };
+		FC047BCB151E500100C5E9E7 /* download.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = download.cpp; sourceTree = "<group>"; };
+		FC047BCC151E500100C5E9E7 /* download.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = download.h; sourceTree = "<group>"; };
+		FC047BCD151E500100C5E9E7 /* gamehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gamehandler.h; sourceTree = "<group>"; };
+		FC047BCE151E500100C5E9E7 /* generalhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generalhandler.h; sourceTree = "<group>"; };
+		FC047BCF151E500100C5E9E7 /* guildhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = guildhandler.h; sourceTree = "<group>"; };
+		FC047BD0151E500100C5E9E7 /* inventoryhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inventoryhandler.h; sourceTree = "<group>"; };
+		FC047BD1151E500100C5E9E7 /* logindata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = logindata.h; sourceTree = "<group>"; };
+		FC047BD2151E500100C5E9E7 /* loginhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loginhandler.h; sourceTree = "<group>"; };
+		FC047BD4151E500100C5E9E7 /* adminhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = adminhandler.cpp; sourceTree = "<group>"; };
+		FC047BD5151E500100C5E9E7 /* adminhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adminhandler.h; sourceTree = "<group>"; };
+		FC047BD6151E500100C5E9E7 /* attributes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = attributes.cpp; sourceTree = "<group>"; };
+		FC047BD7151E500100C5E9E7 /* attributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = attributes.h; sourceTree = "<group>"; };
+		FC047BD8151E500100C5E9E7 /* beinghandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = beinghandler.cpp; sourceTree = "<group>"; };
+		FC047BD9151E500100C5E9E7 /* beinghandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = beinghandler.h; sourceTree = "<group>"; };
+		FC047BDA151E500100C5E9E7 /* buysellhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = buysellhandler.cpp; sourceTree = "<group>"; };
+		FC047BDB151E500100C5E9E7 /* buysellhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buysellhandler.h; sourceTree = "<group>"; };
+		FC047BDC151E500100C5E9E7 /* charhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = charhandler.cpp; sourceTree = "<group>"; };
+		FC047BDD151E500100C5E9E7 /* charhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = charhandler.h; sourceTree = "<group>"; };
+		FC047BDE151E500100C5E9E7 /* chathandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = chathandler.cpp; sourceTree = "<group>"; };
+		FC047BDF151E500100C5E9E7 /* chathandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chathandler.h; sourceTree = "<group>"; };
+		FC047BE0151E500100C5E9E7 /* connection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = connection.cpp; sourceTree = "<group>"; };
+		FC047BE1151E500100C5E9E7 /* connection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = connection.h; sourceTree = "<group>"; };
+		FC047BE2151E500100C5E9E7 /* defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = defines.h; sourceTree = "<group>"; };
+		FC047BE3151E500100C5E9E7 /* effecthandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = effecthandler.cpp; sourceTree = "<group>"; };
+		FC047BE4151E500100C5E9E7 /* effecthandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = effecthandler.h; sourceTree = "<group>"; };
+		FC047BE5151E500100C5E9E7 /* gamehandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gamehandler.cpp; sourceTree = "<group>"; };
+		FC047BE6151E500100C5E9E7 /* gamehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gamehandler.h; sourceTree = "<group>"; };
+		FC047BE7151E500100C5E9E7 /* generalhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = generalhandler.cpp; sourceTree = "<group>"; };
+		FC047BE8151E500100C5E9E7 /* generalhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generalhandler.h; sourceTree = "<group>"; };
+		FC047BE9151E500100C5E9E7 /* guildhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guildhandler.cpp; sourceTree = "<group>"; };
+		FC047BEA151E500100C5E9E7 /* guildhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = guildhandler.h; sourceTree = "<group>"; };
+		FC047BEB151E500100C5E9E7 /* internal.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = internal.cpp; sourceTree = "<group>"; };
+		FC047BEC151E500100C5E9E7 /* internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
+		FC047BED151E500100C5E9E7 /* inventoryhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inventoryhandler.cpp; sourceTree = "<group>"; };
+		FC047BEE151E500100C5E9E7 /* inventoryhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inventoryhandler.h; sourceTree = "<group>"; };
+		FC047BEF151E500100C5E9E7 /* itemhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itemhandler.cpp; sourceTree = "<group>"; };
+		FC047BF0151E500100C5E9E7 /* itemhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itemhandler.h; sourceTree = "<group>"; };
+		FC047BF1151E500100C5E9E7 /* loginhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loginhandler.cpp; sourceTree = "<group>"; };
+		FC047BF2151E500100C5E9E7 /* loginhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loginhandler.h; sourceTree = "<group>"; };
+		FC047BF3151E500100C5E9E7 /* manaserv_protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = manaserv_protocol.h; sourceTree = "<group>"; };
+		FC047BF4151E500100C5E9E7 /* messagehandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messagehandler.cpp; sourceTree = "<group>"; };
+		FC047BF5151E500100C5E9E7 /* messagehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messagehandler.h; sourceTree = "<group>"; };
+		FC047BF6151E500100C5E9E7 /* messagein.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messagein.cpp; sourceTree = "<group>"; };
+		FC047BF7151E500100C5E9E7 /* messagein.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messagein.h; sourceTree = "<group>"; };
+		FC047BF8151E500100C5E9E7 /* messageout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messageout.cpp; sourceTree = "<group>"; };
+		FC047BF9151E500100C5E9E7 /* messageout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messageout.h; sourceTree = "<group>"; };
+		FC047BFA151E500100C5E9E7 /* network.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network.cpp; sourceTree = "<group>"; };
+		FC047BFB151E500100C5E9E7 /* network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network.h; sourceTree = "<group>"; };
+		FC047BFC151E500100C5E9E7 /* npchandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = npchandler.cpp; sourceTree = "<group>"; };
+		FC047BFD151E500100C5E9E7 /* npchandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = npchandler.h; sourceTree = "<group>"; };
+		FC047BFE151E500100C5E9E7 /* partyhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = partyhandler.cpp; sourceTree = "<group>"; };
+		FC047BFF151E500100C5E9E7 /* partyhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = partyhandler.h; sourceTree = "<group>"; };
+		FC047C00151E500100C5E9E7 /* playerhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = playerhandler.cpp; sourceTree = "<group>"; };
+		FC047C01151E500100C5E9E7 /* playerhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = playerhandler.h; sourceTree = "<group>"; };
+		FC047C02151E500100C5E9E7 /* specialhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = specialhandler.cpp; sourceTree = "<group>"; };
+		FC047C03151E500100C5E9E7 /* specialhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = specialhandler.h; sourceTree = "<group>"; };
+		FC047C04151E500100C5E9E7 /* tradehandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tradehandler.cpp; sourceTree = "<group>"; };
+		FC047C05151E500100C5E9E7 /* tradehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tradehandler.h; sourceTree = "<group>"; };
+		FC047C06151E500100C5E9E7 /* messagehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messagehandler.h; sourceTree = "<group>"; };
+		FC047C0B151E500100C5E9E7 /* net.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = net.cpp; sourceTree = "<group>"; };
+		FC047C0C151E500100C5E9E7 /* net.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = net.h; sourceTree = "<group>"; };
+		FC047C0D151E500100C5E9E7 /* npchandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = npchandler.h; sourceTree = "<group>"; };
+		FC047C0E151E500100C5E9E7 /* partyhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = partyhandler.h; sourceTree = "<group>"; };
+		FC047C0F151E500100C5E9E7 /* playerhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = playerhandler.h; sourceTree = "<group>"; };
+		FC047C10151E500100C5E9E7 /* serverinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serverinfo.h; sourceTree = "<group>"; };
+		FC047C11151E500100C5E9E7 /* specialhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = specialhandler.h; sourceTree = "<group>"; };
+		FC047C13151E500100C5E9E7 /* adminhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = adminhandler.cpp; sourceTree = "<group>"; };
+		FC047C14151E500100C5E9E7 /* adminhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adminhandler.h; sourceTree = "<group>"; };
+		FC047C15151E500100C5E9E7 /* beinghandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = beinghandler.cpp; sourceTree = "<group>"; };
+		FC047C16151E500100C5E9E7 /* beinghandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = beinghandler.h; sourceTree = "<group>"; };
+		FC047C17151E500100C5E9E7 /* buysellhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = buysellhandler.cpp; sourceTree = "<group>"; };
+		FC047C18151E500100C5E9E7 /* buysellhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buysellhandler.h; sourceTree = "<group>"; };
+		FC047C19151E500100C5E9E7 /* charserverhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = charserverhandler.cpp; sourceTree = "<group>"; };
+		FC047C1A151E500100C5E9E7 /* charserverhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = charserverhandler.h; sourceTree = "<group>"; };
+		FC047C1B151E500100C5E9E7 /* chathandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = chathandler.cpp; sourceTree = "<group>"; };
+		FC047C1C151E500100C5E9E7 /* chathandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = chathandler.h; sourceTree = "<group>"; };
+		FC047C1D151E500100C5E9E7 /* gamehandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gamehandler.cpp; sourceTree = "<group>"; };
+		FC047C1E151E500100C5E9E7 /* gamehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gamehandler.h; sourceTree = "<group>"; };
+		FC047C1F151E500100C5E9E7 /* generalhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = generalhandler.cpp; sourceTree = "<group>"; };
+		FC047C20151E500100C5E9E7 /* generalhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = generalhandler.h; sourceTree = "<group>"; };
+		FC047C22151E500100C5E9E7 /* guildtab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guildtab.cpp; sourceTree = "<group>"; };
+		FC047C23151E500100C5E9E7 /* guildtab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = guildtab.h; sourceTree = "<group>"; };
+		FC047C24151E500100C5E9E7 /* partytab.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = partytab.cpp; sourceTree = "<group>"; };
+		FC047C25151E500100C5E9E7 /* partytab.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = partytab.h; sourceTree = "<group>"; };
+		FC047C26151E500100C5E9E7 /* guildhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guildhandler.cpp; sourceTree = "<group>"; };
+		FC047C27151E500100C5E9E7 /* guildhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = guildhandler.h; sourceTree = "<group>"; };
+		FC047C28151E500100C5E9E7 /* inventoryhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = inventoryhandler.cpp; sourceTree = "<group>"; };
+		FC047C29151E500100C5E9E7 /* inventoryhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = inventoryhandler.h; sourceTree = "<group>"; };
+		FC047C2A151E500100C5E9E7 /* itemhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itemhandler.cpp; sourceTree = "<group>"; };
+		FC047C2B151E500100C5E9E7 /* itemhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itemhandler.h; sourceTree = "<group>"; };
+		FC047C2C151E500100C5E9E7 /* loginhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = loginhandler.cpp; sourceTree = "<group>"; };
+		FC047C2D151E500100C5E9E7 /* loginhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = loginhandler.h; sourceTree = "<group>"; };
+		FC047C2E151E500100C5E9E7 /* messagehandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messagehandler.cpp; sourceTree = "<group>"; };
+		FC047C2F151E500100C5E9E7 /* messagehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messagehandler.h; sourceTree = "<group>"; };
+		FC047C30151E500100C5E9E7 /* messagein.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messagein.cpp; sourceTree = "<group>"; };
+		FC047C31151E500100C5E9E7 /* messagein.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messagein.h; sourceTree = "<group>"; };
+		FC047C32151E500100C5E9E7 /* messageout.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = messageout.cpp; sourceTree = "<group>"; };
+		FC047C33151E500100C5E9E7 /* messageout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = messageout.h; sourceTree = "<group>"; };
+		FC047C34151E500100C5E9E7 /* network.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = network.cpp; sourceTree = "<group>"; };
+		FC047C35151E500100C5E9E7 /* network.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = network.h; sourceTree = "<group>"; };
+		FC047C36151E500100C5E9E7 /* npchandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = npchandler.cpp; sourceTree = "<group>"; };
+		FC047C37151E500100C5E9E7 /* npchandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = npchandler.h; sourceTree = "<group>"; };
+		FC047C38151E500100C5E9E7 /* partyhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = partyhandler.cpp; sourceTree = "<group>"; };
+		FC047C39151E500100C5E9E7 /* partyhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = partyhandler.h; sourceTree = "<group>"; };
+		FC047C3A151E500100C5E9E7 /* playerhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = playerhandler.cpp; sourceTree = "<group>"; };
+		FC047C3B151E500100C5E9E7 /* playerhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = playerhandler.h; sourceTree = "<group>"; };
+		FC047C3C151E500100C5E9E7 /* protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = protocol.h; sourceTree = "<group>"; };
+		FC047C3D151E500100C5E9E7 /* specialhandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = specialhandler.cpp; sourceTree = "<group>"; };
+		FC047C3E151E500100C5E9E7 /* specialhandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = specialhandler.h; sourceTree = "<group>"; };
+		FC047C3F151E500100C5E9E7 /* token.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = token.h; sourceTree = "<group>"; };
+		FC047C40151E500100C5E9E7 /* tradehandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tradehandler.cpp; sourceTree = "<group>"; };
+		FC047C41151E500100C5E9E7 /* tradehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tradehandler.h; sourceTree = "<group>"; };
+		FC047C42151E500100C5E9E7 /* tradehandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tradehandler.h; sourceTree = "<group>"; };
+		FC047C43151E500100C5E9E7 /* worldinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = worldinfo.h; sourceTree = "<group>"; };
+		FC047C78151E500C00C5E9E7 /* action.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = action.cpp; sourceTree = "<group>"; };
+		FC047C79151E500C00C5E9E7 /* action.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = action.h; sourceTree = "<group>"; };
+		FC047C7A151E500C00C5E9E7 /* ambientlayer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ambientlayer.cpp; sourceTree = "<group>"; };
+		FC047C7B151E500C00C5E9E7 /* ambientlayer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ambientlayer.h; sourceTree = "<group>"; };
+		FC047C7C151E500C00C5E9E7 /* animation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = animation.cpp; sourceTree = "<group>"; };
+		FC047C7D151E500C00C5E9E7 /* animation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = animation.h; sourceTree = "<group>"; };
+		FC047C7E151E500C00C5E9E7 /* beinginfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = beinginfo.cpp; sourceTree = "<group>"; };
+		FC047C7F151E500C00C5E9E7 /* beinginfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = beinginfo.h; sourceTree = "<group>"; };
+		FC047C80151E500C00C5E9E7 /* dye.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dye.cpp; sourceTree = "<group>"; };
+		FC047C81151E500C00C5E9E7 /* dye.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dye.h; sourceTree = "<group>"; };
+		FC047C82151E500C00C5E9E7 /* emotedb.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = emotedb.cpp; sourceTree = "<group>"; };
+		FC047C83151E500C00C5E9E7 /* emotedb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = emotedb.h; sourceTree = "<group>"; };
+		FC047C84151E500C00C5E9E7 /* hairdb.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hairdb.cpp; sourceTree = "<group>"; };
+		FC047C85151E500C00C5E9E7 /* hairdb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hairdb.h; sourceTree = "<group>"; };
+		FC047C86151E500C00C5E9E7 /* image.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = image.cpp; sourceTree = "<group>"; };
+		FC047C87151E500C00C5E9E7 /* image.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = image.h; sourceTree = "<group>"; };
+		FC047C88151E500C00C5E9E7 /* imageloader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = imageloader.cpp; sourceTree = "<group>"; };
+		FC047C89151E500C00C5E9E7 /* imageloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = imageloader.h; sourceTree = "<group>"; };
+		FC047C8A151E500C00C5E9E7 /* imageset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = imageset.cpp; sourceTree = "<group>"; };
+		FC047C8B151E500C00C5E9E7 /* imageset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = imageset.h; sourceTree = "<group>"; };
+		FC047C8C151E500C00C5E9E7 /* imagewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = imagewriter.cpp; sourceTree = "<group>"; };
+		FC047C8D151E500C00C5E9E7 /* imagewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = imagewriter.h; sourceTree = "<group>"; };
+		FC047C8E151E500C00C5E9E7 /* itemdb.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = itemdb.cpp; sourceTree = "<group>"; };
+		FC047C8F151E500C00C5E9E7 /* itemdb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = itemdb.h; sourceTree = "<group>"; };
+		FC047C90151E500C00C5E9E7 /* iteminfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = iteminfo.cpp; sourceTree = "<group>"; };
+		FC047C91151E500C00C5E9E7 /* iteminfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iteminfo.h; sourceTree = "<group>"; };
+		FC047C92151E500C00C5E9E7 /* mapreader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mapreader.cpp; sourceTree = "<group>"; };
+		FC047C93151E500C00C5E9E7 /* mapreader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mapreader.h; sourceTree = "<group>"; };
+		FC047C94151E500C00C5E9E7 /* monsterdb.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = monsterdb.cpp; sourceTree = "<group>"; };
+		FC047C95151E500C00C5E9E7 /* monsterdb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = monsterdb.h; sourceTree = "<group>"; };
+		FC047C96151E500C00C5E9E7 /* music.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = music.cpp; sourceTree = "<group>"; };
+		FC047C97151E500C00C5E9E7 /* music.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = music.h; sourceTree = "<group>"; };
+		FC047C98151E500C00C5E9E7 /* npcdb.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = npcdb.cpp; sourceTree = "<group>"; };
+		FC047C99151E500C00C5E9E7 /* npcdb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = npcdb.h; sourceTree = "<group>"; };
+		FC047C9A151E500C00C5E9E7 /* resource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resource.cpp; sourceTree = "<group>"; };
+		FC047C9B151E500C00C5E9E7 /* resource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resource.h; sourceTree = "<group>"; };
+		FC047C9C151E500C00C5E9E7 /* resourcemanager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resourcemanager.cpp; sourceTree = "<group>"; };
+		FC047C9D151E500C00C5E9E7 /* resourcemanager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = resourcemanager.h; sourceTree = "<group>"; };
+		FC047C9E151E500C00C5E9E7 /* soundeffect.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = soundeffect.cpp; sourceTree = "<group>"; };
+		FC047C9F151E500C00C5E9E7 /* soundeffect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = soundeffect.h; sourceTree = "<group>"; };
+		FC047CA0151E500C00C5E9E7 /* specialdb.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = specialdb.cpp; sourceTree = "<group>"; };
+		FC047CA1151E500C00C5E9E7 /* specialdb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = specialdb.h; sourceTree = "<group>"; };
+		FC047CA2151E500C00C5E9E7 /* spritedef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = spritedef.cpp; sourceTree = "<group>"; };
+		FC047CA3151E500C00C5E9E7 /* spritedef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spritedef.h; sourceTree = "<group>"; };
+		FC047CA4151E500C00C5E9E7 /* theme.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = theme.cpp; sourceTree = "<group>"; };
+		FC047CA5151E500C00C5E9E7 /* theme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = theme.h; sourceTree = "<group>"; };
+		FC047CA6151E500C00C5E9E7 /* userpalette.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = userpalette.cpp; sourceTree = "<group>"; };
+		FC047CA7151E500C00C5E9E7 /* userpalette.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = userpalette.h; sourceTree = "<group>"; };
+		FC047CA8151E500C00C5E9E7 /* wallpaper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = wallpaper.cpp; sourceTree = "<group>"; };
+		FC047CA9151E500C00C5E9E7 /* wallpaper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wallpaper.h; sourceTree = "<group>"; };
+		FC047CC4151E501400C5E9E7 /* base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = base64.cpp; sourceTree = "<group>"; };
+		FC047CC5151E501400C5E9E7 /* base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = base64.h; sourceTree = "<group>"; };
+		FC047CC6151E501400C5E9E7 /* copynpaste.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = copynpaste.cpp; sourceTree = "<group>"; };
+		FC047CC7151E501400C5E9E7 /* copynpaste.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = copynpaste.h; sourceTree = "<group>"; };
+		FC047CC8151E501400C5E9E7 /* dtor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dtor.h; sourceTree = "<group>"; };
+		FC047CC9151E501400C5E9E7 /* gettext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gettext.h; sourceTree = "<group>"; };
+		FC047CCA151E501400C5E9E7 /* mathutils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mathutils.h; sourceTree = "<group>"; };
+		FC047CCB151E501400C5E9E7 /* mkdir.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mkdir.cpp; sourceTree = "<group>"; };
+		FC047CCC151E501400C5E9E7 /* mkdir.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mkdir.h; sourceTree = "<group>"; };
+		FC047CCD151E501400C5E9E7 /* mutex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutex.h; sourceTree = "<group>"; };
+		FC047CCE151E501400C5E9E7 /* physfsrwops.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = physfsrwops.c; sourceTree = "<group>"; };
+		FC047CCF151E501400C5E9E7 /* physfsrwops.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = physfsrwops.h; sourceTree = "<group>"; };
+		FC047CD0151E501400C5E9E7 /* sha256.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sha256.cpp; sourceTree = "<group>"; };
+		FC047CD1151E501400C5E9E7 /* sha256.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha256.h; sourceTree = "<group>"; };
+		FC047CD2151E501400C5E9E7 /* specialfolder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = specialfolder.cpp; sourceTree = "<group>"; };
+		FC047CD3151E501400C5E9E7 /* specialfolder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = specialfolder.h; sourceTree = "<group>"; };
+		FC047CD4151E501400C5E9E7 /* stringutils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = stringutils.cpp; sourceTree = "<group>"; };
+		FC047CD5151E501400C5E9E7 /* stringutils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stringutils.h; sourceTree = "<group>"; };
+		FC047CD6151E501400C5E9E7 /* xml.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = xml.cpp; sourceTree = "<group>"; };
+		FC047CD7151E501400C5E9E7 /* xml.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = xml.h; sourceTree = "<group>"; };
+		FC047CD8151E501400C5E9E7 /* zlib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = zlib.cpp; sourceTree = "<group>"; };
+		FC047CD9151E501400C5E9E7 /* zlib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zlib.h; sourceTree = "<group>"; };
+		FC047CE5151E747B00C5E9E7 /* log.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = log.mm; path = ../../src/log.mm; sourceTree = "<group>"; };
+		FC047CE8151E7C8500C5E9E7 /* cstdint */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = cstdint; sourceTree = "<group>"; };
+		FC047CEB151E820000C5E9E7 /* callbacks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = callbacks.c; sourceTree = "<group>"; };
+		FC047CEE151E820000C5E9E7 /* compress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = compress.c; sourceTree = "<group>"; };
+		FC047CF0151E820000C5E9E7 /* host.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = host.c; sourceTree = "<group>"; };
+		FC047CF3151E820000C5E9E7 /* callbacks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = callbacks.h; sourceTree = "<group>"; };
+		FC047CF4151E820000C5E9E7 /* enet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = enet.h; sourceTree = "<group>"; };
+		FC047CF5151E820000C5E9E7 /* list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = list.h; sourceTree = "<group>"; };
+		FC047CF6151E820000C5E9E7 /* protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = protocol.h; sourceTree = "<group>"; };
+		FC047CF7151E820000C5E9E7 /* time.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = time.h; sourceTree = "<group>"; };
+		FC047CF8151E820000C5E9E7 /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
+		FC047CF9151E820000C5E9E7 /* unix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unix.h; sourceTree = "<group>"; };
+		FC047CFA151E820000C5E9E7 /* utility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utility.h; sourceTree = "<group>"; };
+		FC047CFB151E820000C5E9E7 /* win32.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = win32.h; sourceTree = "<group>"; };
+		FC047CFD151E820000C5E9E7 /* list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = list.c; sourceTree = "<group>"; };
+		FC047CFE151E820000C5E9E7 /* packet.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = packet.c; sourceTree = "<group>"; };
+		FC047CFF151E820000C5E9E7 /* peer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = peer.c; sourceTree = "<group>"; };
+		FC047D00151E820000C5E9E7 /* protocol.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = protocol.c; sourceTree = "<group>"; };
+		FC047D02151E820000C5E9E7 /* unix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unix.c; sourceTree = "<group>"; };
+		FC047D15151E853200C5E9E7 /* libSDL_gfx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSDL_gfx.a; path = ../libs/libSDL_gfx.a; sourceTree = "<group>"; };
+		FC047D16151E853300C5E9E7 /* libxml2.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libxml2.a; path = ../libs/libxml2.a; sourceTree = "<group>"; };
+		FC047D1C151E856400C5E9E7 /* libphysfs.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libphysfs.a; path = ../libs/libphysfs.a; sourceTree = "<group>"; };
+		FC047D1E151E860600C5E9E7 /* libpng.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libpng.a; path = ../libs/libpng.a; sourceTree = "<group>"; };
+		FC047D22151E878A00C5E9E7 /* libSDL_net.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSDL_net.a; path = ../libs/libSDL_net.a; sourceTree = "<group>"; };
+		FC047D23151E878A00C5E9E7 /* libSDL_ttf.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSDL_ttf.a; path = ../libs/libSDL_ttf.a; sourceTree = "<group>"; };
+		FC047D28151E88A500C5E9E7 /* libfreetype.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libfreetype.a; path = ../libs/libfreetype.a; sourceTree = "<group>"; };
+		FC047D2A151E898300C5E9E7 /* libiconv.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libiconv.a; path = ../libs/libiconv.a; sourceTree = "<group>"; };
+		FC047D2C151E89D200C5E9E7 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		FC047D2E151E8E9400C5E9E7 /* libintl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libintl.a; path = ../libs/libintl.a; sourceTree = "<group>"; };
+		FC047D30151E8F8200C5E9E7 /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; name = data; path = ../../data; sourceTree = "<group>"; };
+		FC047D3A151E94B500C5E9E7 /* libguichan_opengl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libguichan_opengl.a; path = ../libs/libguichan_opengl.a; sourceTree = "<group>"; };
+		FC047D3B151E94B500C5E9E7 /* libguichan_sdl.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libguichan_sdl.a; path = ../libs/libguichan_sdl.a; sourceTree = "<group>"; };
+		FC047D3C151E94B500C5E9E7 /* libguichan.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libguichan.a; path = ../libs/libguichan.a; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FC0479C3151E4DB700C5E9E7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2FBA050D15B8EE77001AB720 /* SDL.framework in Frameworks */,
+				2FBA050E15B8EFBF001AB720 /* SDL_image.framework in Frameworks */,
+				2FBA050F15B8EFBF001AB720 /* SDL_mixer.framework in Frameworks */,
+				FC047D2D151E89D300C5E9E7 /* IOKit.framework in Frameworks */,
+				FC0479CB151E4DB700C5E9E7 /* Cocoa.framework in Frameworks */,
+				FC047D1A151E853300C5E9E7 /* libSDL_gfx.a in Frameworks */,
+				FC047D1B151E853300C5E9E7 /* libxml2.a in Frameworks */,
+				FC047D1D151E856400C5E9E7 /* libphysfs.a in Frameworks */,
+				FC047D1F151E860600C5E9E7 /* libpng.a in Frameworks */,
+				FC047D24151E878A00C5E9E7 /* libSDL_net.a in Frameworks */,
+				FC047D25151E878A00C5E9E7 /* libSDL_ttf.a in Frameworks */,
+				FC047D29151E88A500C5E9E7 /* libfreetype.a in Frameworks */,
+				FC047D2B151E898300C5E9E7 /* libiconv.a in Frameworks */,
+				FC047D2F151E8E9400C5E9E7 /* libintl.a in Frameworks */,
+				FC047D3D151E94B500C5E9E7 /* libguichan_opengl.a in Frameworks */,
+				FC047D3E151E94B500C5E9E7 /* libguichan_sdl.a in Frameworks */,
+				FC047D3F151E94B500C5E9E7 /* libguichan.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		FC0479BB151E4DB700C5E9E7 = {
+			isa = PBXGroup;
+			children = (
+				2FBA050715B8ED6D001AB720 /* SDL_image.framework */,
+				2FBA050515B8ED59001AB720 /* SDL_mixer.framework */,
+				2FBA050315B8ED49001AB720 /* SDL.framework */,
+				FC0479D0151E4DB700C5E9E7 /* mana */,
+				FC0479C9151E4DB700C5E9E7 /* Frameworks */,
+				FC0479C7151E4DB700C5E9E7 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		FC0479C7151E4DB700C5E9E7 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FC0479C6151E4DB700C5E9E7 /* mana.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		FC0479C9151E4DB700C5E9E7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FC047D28151E88A500C5E9E7 /* libfreetype.a */,
+				FC047D3C151E94B500C5E9E7 /* libguichan.a */,
+				FC047D3A151E94B500C5E9E7 /* libguichan_opengl.a */,
+				FC047D3B151E94B500C5E9E7 /* libguichan_sdl.a */,
+				FC047D2A151E898300C5E9E7 /* libiconv.a */,
+				FC047D2E151E8E9400C5E9E7 /* libintl.a */,
+				FC047D1C151E856400C5E9E7 /* libphysfs.a */,
+				FC047D1E151E860600C5E9E7 /* libpng.a */,
+				FC047D15151E853200C5E9E7 /* libSDL_gfx.a */,
+				FC047D22151E878A00C5E9E7 /* libSDL_net.a */,
+				FC047D23151E878A00C5E9E7 /* libSDL_ttf.a */,
+				FC047D16151E853300C5E9E7 /* libxml2.a */,
+				FC047D2C151E89D200C5E9E7 /* IOKit.framework */,
+				FC0479CA151E4DB700C5E9E7 /* Cocoa.framework */,
+				FC0479CC151E4DB700C5E9E7 /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FC0479CC151E4DB700C5E9E7 /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FC0479CD151E4DB700C5E9E7 /* AppKit.framework */,
+				FC0479CE151E4DB700C5E9E7 /* CoreData.framework */,
+				FC0479CF151E4DB700C5E9E7 /* Foundation.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		FC0479D0151E4DB700C5E9E7 /* mana */ = {
+			isa = PBXGroup;
+			children = (
+				FC047CEA151E820000C5E9E7 /* enet */,
+				FC047CE7151E7C8500C5E9E7 /* cpp0x_compat */,
+				FC0479E7151E4F8800C5E9E7 /* actor.cpp */,
+				FC0479E8151E4F8800C5E9E7 /* actor.h */,
+				FC0479E9151E4F8800C5E9E7 /* actorsprite.cpp */,
+				FC0479EA151E4F8800C5E9E7 /* actorsprite.h */,
+				FC0479EB151E4F8800C5E9E7 /* actorspritemanager.cpp */,
+				FC0479EC151E4F8800C5E9E7 /* actorspritemanager.h */,
+				FC0479ED151E4F8800C5E9E7 /* animatedsprite.cpp */,
+				FC0479EE151E4F8800C5E9E7 /* animatedsprite.h */,
+				FC0479EF151E4F8800C5E9E7 /* animationparticle.cpp */,
+				FC0479F0151E4F8800C5E9E7 /* animationparticle.h */,
+				FC0479F1151E4F8800C5E9E7 /* avatar.cpp */,
+				FC0479F2151E4F8800C5E9E7 /* avatar.h */,
+				FC0479F3151E4F8800C5E9E7 /* being.cpp */,
+				FC0479F4151E4F8800C5E9E7 /* being.h */,
+				FC0479F5151E4F8800C5E9E7 /* channel.cpp */,
+				FC0479F6151E4F8800C5E9E7 /* channel.h */,
+				FC0479F7151E4F8800C5E9E7 /* channelmanager.cpp */,
+				FC0479F8151E4F8800C5E9E7 /* channelmanager.h */,
+				FC0479F9151E4F8800C5E9E7 /* chatlogger.cpp */,
+				FC0479FA151E4F8800C5E9E7 /* chatlogger.h */,
+				FC0479FB151E4F8800C5E9E7 /* client.cpp */,
+				FC0479FC151E4F8800C5E9E7 /* client.h */,
+				FC0479FD151E4F8800C5E9E7 /* commandhandler.cpp */,
+				FC0479FE151E4F8800C5E9E7 /* commandhandler.h */,
+				FC0479FF151E4F8800C5E9E7 /* compoundsprite.cpp */,
+				FC047A00151E4F8800C5E9E7 /* compoundsprite.h */,
+				FC047A01151E4F8800C5E9E7 /* configuration.cpp */,
+				FC047A02151E4F8800C5E9E7 /* configuration.h */,
+				FC047A03151E4F8800C5E9E7 /* defaults.cpp */,
+				FC047A04151E4F8800C5E9E7 /* defaults.h */,
+				FC047A05151E4F8800C5E9E7 /* effectmanager.cpp */,
+				FC047A06151E4F8800C5E9E7 /* effectmanager.h */,
+				FC047A07151E4F8800C5E9E7 /* emoteshortcut.cpp */,
+				FC047A08151E4F8800C5E9E7 /* emoteshortcut.h */,
+				FC047A09151E4F8800C5E9E7 /* equipment.h */,
+				FC047A0A151E4F8800C5E9E7 /* event.cpp */,
+				FC047A0B151E4F8800C5E9E7 /* event.h */,
+				FC047A0C151E4F8800C5E9E7 /* eventlistener.cpp */,
+				FC047A0D151E4F8800C5E9E7 /* eventlistener.h */,
+				FC047A0E151E4F8800C5E9E7 /* flooritem.cpp */,
+				FC047A0F151E4F8800C5E9E7 /* flooritem.h */,
+				FC047A10151E4F8800C5E9E7 /* game.cpp */,
+				FC047A11151E4F8800C5E9E7 /* game.h */,
+				FC047A12151E4F8800C5E9E7 /* graphics.cpp */,
+				FC047A29151E4FC700C5E9E7 /* graphics.h */,
+				FC047A8E151E4FF700C5E9E7 /* gui */,
+				FC047A2A151E4FC700C5E9E7 /* guichanfwd.h */,
+				FC047A2B151E4FC700C5E9E7 /* guild.cpp */,
+				FC047A2C151E4FC700C5E9E7 /* guild.h */,
+				FC047A2D151E4FC700C5E9E7 /* imageparticle.cpp */,
+				FC047A2E151E4FC700C5E9E7 /* imageparticle.h */,
+				FC047A2F151E4FC700C5E9E7 /* imagesprite.cpp */,
+				FC047A30151E4FC700C5E9E7 /* imagesprite.h */,
+				FC047A31151E4FC700C5E9E7 /* inventory.cpp */,
+				FC047A32151E4FC700C5E9E7 /* inventory.h */,
+				FC047A33151E4FC700C5E9E7 /* item.cpp */,
+				FC047A34151E4FC700C5E9E7 /* item.h */,
+				FC047A35151E4FC700C5E9E7 /* itemshortcut.cpp */,
+				FC047A36151E4FC700C5E9E7 /* itemshortcut.h */,
+				FC047A37151E4FC700C5E9E7 /* joystick.cpp */,
+				FC047A38151E4FC700C5E9E7 /* joystick.h */,
+				FC047A39151E4FC700C5E9E7 /* keyboardconfig.cpp */,
+				FC047A3A151E4FC700C5E9E7 /* keyboardconfig.h */,
+				FC047A3B151E4FC700C5E9E7 /* localplayer.cpp */,
+				FC047A3C151E4FC700C5E9E7 /* localplayer.h */,
+				FC047CE5151E747B00C5E9E7 /* log.mm */,
+				FC047A3D151E4FC700C5E9E7 /* log.cpp */,
+				FC047A3E151E4FC700C5E9E7 /* log.h */,
+				FC047A3F151E4FC700C5E9E7 /* main.cpp */,
+				FC047A40151E4FC700C5E9E7 /* main.h */,
+				FC047A41151E4FC700C5E9E7 /* map.cpp */,
+				FC047A42151E4FC700C5E9E7 /* map.h */,
+				FC047BC6151E500100C5E9E7 /* net */,
+				FC047A43151E4FC700C5E9E7 /* openglgraphics.cpp */,
+				FC047A44151E4FC700C5E9E7 /* openglgraphics.h */,
+				FC047A45151E4FC700C5E9E7 /* particle.cpp */,
+				FC047A46151E4FC700C5E9E7 /* particle.h */,
+				FC047A47151E4FC700C5E9E7 /* particlecontainer.cpp */,
+				FC047A48151E4FC700C5E9E7 /* particlecontainer.h */,
+				FC047A49151E4FC700C5E9E7 /* particleemitter.cpp */,
+				FC047A4A151E4FC700C5E9E7 /* particleemitter.h */,
+				FC047A4B151E4FC700C5E9E7 /* particleemitterprop.h */,
+				FC047A4C151E4FC700C5E9E7 /* party.cpp */,
+				FC047A4D151E4FC700C5E9E7 /* party.h */,
+				FC047A4E151E4FC700C5E9E7 /* playerinfo.cpp */,
+				FC047A4F151E4FC700C5E9E7 /* playerinfo.h */,
+				FC047A50151E4FC700C5E9E7 /* playerrelations.cpp */,
+				FC047A51151E4FC700C5E9E7 /* playerrelations.h */,
+				FC047A52151E4FC700C5E9E7 /* position.cpp */,
+				FC047A53151E4FC700C5E9E7 /* position.h */,
+				FC047A54151E4FC700C5E9E7 /* properties.h */,
+				FC047C77151E500C00C5E9E7 /* resources */,
+				FC047A55151E4FC700C5E9E7 /* rotationalparticle.cpp */,
+				FC047A56151E4FC700C5E9E7 /* rotationalparticle.h */,
+				FC047A57151E4FC700C5E9E7 /* SDLMain.h */,
+				FC047A58151E4FC700C5E9E7 /* SDLMain.m */,
+				FC047A59151E4FC700C5E9E7 /* shopitem.cpp */,
+				FC047A5A151E4FC700C5E9E7 /* shopitem.h */,
+				FC047A5B151E4FC700C5E9E7 /* simpleanimation.cpp */,
+				FC047A5C151E4FC700C5E9E7 /* simpleanimation.h */,
+				FC047A5D151E4FC700C5E9E7 /* sound.cpp */,
+				FC047A5E151E4FC700C5E9E7 /* sound.h */,
+				FC047A5F151E4FC700C5E9E7 /* sprite.h */,
+				FC047A60151E4FC700C5E9E7 /* statuseffect.cpp */,
+				FC047A61151E4FC700C5E9E7 /* statuseffect.h */,
+				FC047A62151E4FC700C5E9E7 /* text.cpp */,
+				FC047A63151E4FC700C5E9E7 /* text.h */,
+				FC047A64151E4FC700C5E9E7 /* textmanager.cpp */,
+				FC047A65151E4FC700C5E9E7 /* textmanager.h */,
+				FC047A66151E4FC700C5E9E7 /* textparticle.cpp */,
+				FC047A67151E4FC700C5E9E7 /* textparticle.h */,
+				FC047A68151E4FC700C5E9E7 /* textrenderer.h */,
+				FC047A69151E4FC700C5E9E7 /* tileset.h */,
+				FC047A6A151E4FC700C5E9E7 /* units.cpp */,
+				FC047A6B151E4FC700C5E9E7 /* units.h */,
+				FC047CC3151E501400C5E9E7 /* utils */,
+				FC047A6C151E4FC700C5E9E7 /* variabledata.h */,
+				FC047A6D151E4FC700C5E9E7 /* vector.cpp */,
+				FC047A6E151E4FC700C5E9E7 /* vector.h */,
+				FC0479DF151E4DB800C5E9E7 /* MainMenu.xib */,
+				FC0479D1151E4DB700C5E9E7 /* Supporting Files */,
+			);
+			path = mana;
+			sourceTree = "<group>";
+		};
+		FC0479D1151E4DB700C5E9E7 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				FC047D30151E8F8200C5E9E7 /* data */,
+				FC0479D2151E4DB700C5E9E7 /* mana-Info.plist */,
+				FC0479D3151E4DB700C5E9E7 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		FC047A8E151E4FF700C5E9E7 /* gui */ = {
+			isa = PBXGroup;
+			children = (
+				FC047A8F151E4FF700C5E9E7 /* beingpopup.cpp */,
+				FC047A90151E4FF700C5E9E7 /* beingpopup.h */,
+				FC047A91151E4FF700C5E9E7 /* buydialog.cpp */,
+				FC047A92151E4FF700C5E9E7 /* buydialog.h */,
+				FC047A93151E4FF700C5E9E7 /* buyselldialog.cpp */,
+				FC047A94151E4FF700C5E9E7 /* buyselldialog.h */,
+				FC047A95151E4FF700C5E9E7 /* changeemaildialog.cpp */,
+				FC047A96151E4FF700C5E9E7 /* changeemaildialog.h */,
+				FC047A97151E4FF700C5E9E7 /* changepassworddialog.cpp */,
+				FC047A98151E4FF700C5E9E7 /* changepassworddialog.h */,
+				FC047A99151E4FF700C5E9E7 /* charcreatedialog.cpp */,
+				FC047A9A151E4FF700C5E9E7 /* charcreatedialog.h */,
+				FC047A9B151E4FF700C5E9E7 /* charselectdialog.cpp */,
+				FC047A9C151E4FF700C5E9E7 /* charselectdialog.h */,
+				FC047A9D151E4FF700C5E9E7 /* chatwindow.cpp */,
+				FC047A9E151E4FF700C5E9E7 /* chatwindow.h */,
+				FC047A9F151E4FF700C5E9E7 /* confirmdialog.cpp */,
+				FC047AA0151E4FF700C5E9E7 /* confirmdialog.h */,
+				FC047AA1151E4FF700C5E9E7 /* connectiondialog.cpp */,
+				FC047AA2151E4FF700C5E9E7 /* connectiondialog.h */,
+				FC047AA3151E4FF700C5E9E7 /* customserverdialog.cpp */,
+				FC047AA4151E4FF700C5E9E7 /* customserverdialog.h */,
+				FC047AA5151E4FF700C5E9E7 /* debugwindow.cpp */,
+				FC047AA6151E4FF700C5E9E7 /* debugwindow.h */,
+				FC047AA7151E4FF700C5E9E7 /* emotepopup.cpp */,
+				FC047AA8151E4FF700C5E9E7 /* emotepopup.h */,
+				FC047AA9151E4FF700C5E9E7 /* equipmentwindow.cpp */,
+				FC047AAA151E4FF700C5E9E7 /* equipmentwindow.h */,
+				FC047AAB151E4FF700C5E9E7 /* focushandler.cpp */,
+				FC047AAC151E4FF700C5E9E7 /* focushandler.h */,
+				FC047AAD151E4FF700C5E9E7 /* gui.cpp */,
+				FC047AAE151E4FF700C5E9E7 /* gui.h */,
+				FC047AAF151E4FF700C5E9E7 /* helpwindow.cpp */,
+				FC047AB0151E4FF700C5E9E7 /* helpwindow.h */,
+				FC047AB1151E4FF700C5E9E7 /* inventorywindow.cpp */,
+				FC047AB2151E4FF700C5E9E7 /* inventorywindow.h */,
+				FC047AB3151E4FF700C5E9E7 /* itemamountwindow.cpp */,
+				FC047AB4151E4FF700C5E9E7 /* itemamountwindow.h */,
+				FC047AB5151E4FF700C5E9E7 /* itempopup.cpp */,
+				FC047AB6151E4FF700C5E9E7 /* itempopup.h */,
+				FC047AB7151E4FF700C5E9E7 /* logindialog.cpp */,
+				FC047AB8151E4FF700C5E9E7 /* logindialog.h */,
+				FC047AB9151E4FF700C5E9E7 /* minimap.cpp */,
+				FC047ABA151E4FF700C5E9E7 /* minimap.h */,
+				FC047ABB151E4FF700C5E9E7 /* ministatuswindow.cpp */,
+				FC047ABC151E4FF700C5E9E7 /* ministatuswindow.h */,
+				FC047ABD151E4FF700C5E9E7 /* npcdialog.cpp */,
+				FC047ABE151E4FF700C5E9E7 /* npcdialog.h */,
+				FC047ABF151E4FF700C5E9E7 /* npcpostdialog.cpp */,
+				FC047AC0151E4FF700C5E9E7 /* npcpostdialog.h */,
+				FC047AC1151E4FF700C5E9E7 /* okdialog.cpp */,
+				FC047AC2151E4FF700C5E9E7 /* okdialog.h */,
+				FC047AC3151E4FF700C5E9E7 /* outfitwindow.cpp */,
+				FC047AC4151E4FF700C5E9E7 /* outfitwindow.h */,
+				FC047AC5151E4FF700C5E9E7 /* palette.cpp */,
+				FC047AC6151E4FF700C5E9E7 /* palette.h */,
+				FC047AC7151E4FF700C5E9E7 /* popupmenu.cpp */,
+				FC047AC8151E4FF700C5E9E7 /* popupmenu.h */,
+				FC047AC9151E4FF700C5E9E7 /* quitdialog.cpp */,
+				FC047ACA151E4FF700C5E9E7 /* quitdialog.h */,
+				FC047ACB151E4FF700C5E9E7 /* recorder.cpp */,
+				FC047ACC151E4FF700C5E9E7 /* recorder.h */,
+				FC047ACD151E4FF700C5E9E7 /* register.cpp */,
+				FC047ACE151E4FF700C5E9E7 /* register.h */,
+				FC047ACF151E4FF700C5E9E7 /* sdlinput.cpp */,
+				FC047AD0151E4FF700C5E9E7 /* sdlinput.h */,
+				FC047AD1151E4FF700C5E9E7 /* selldialog.cpp */,
+				FC047AD2151E4FF700C5E9E7 /* selldialog.h */,
+				FC047AD3151E4FF700C5E9E7 /* serverdialog.cpp */,
+				FC047AD4151E4FF700C5E9E7 /* serverdialog.h */,
+				FC047AD5151E4FF700C5E9E7 /* setup.cpp */,
+				FC047AD6151E4FF700C5E9E7 /* setup.h */,
+				FC047AD7151E4FF700C5E9E7 /* setup_audio.cpp */,
+				FC047AD8151E4FF700C5E9E7 /* setup_audio.h */,
+				FC047AD9151E4FF700C5E9E7 /* setup_colors.cpp */,
+				FC047ADA151E4FF700C5E9E7 /* setup_colors.h */,
+				FC047ADB151E4FF700C5E9E7 /* setup_interface.cpp */,
+				FC047ADC151E4FF700C5E9E7 /* setup_interface.h */,
+				FC047ADD151E4FF700C5E9E7 /* setup_joystick.cpp */,
+				FC047ADE151E4FF700C5E9E7 /* setup_joystick.h */,
+				FC047ADF151E4FF700C5E9E7 /* setup_keyboard.cpp */,
+				FC047AE0151E4FF700C5E9E7 /* setup_keyboard.h */,
+				FC047AE1151E4FF700C5E9E7 /* setup_players.cpp */,
+				FC047AE2151E4FF700C5E9E7 /* setup_players.h */,
+				FC047AE3151E4FF700C5E9E7 /* setup_video.cpp */,
+				FC047AE4151E4FF700C5E9E7 /* setup_video.h */,
+				FC047AE5151E4FF700C5E9E7 /* shortcutwindow.cpp */,
+				FC047AE6151E4FF700C5E9E7 /* shortcutwindow.h */,
+				FC047AE7151E4FF700C5E9E7 /* skilldialog.cpp */,
+				FC047AE8151E4FF700C5E9E7 /* skilldialog.h */,
+				FC047AE9151E4FF700C5E9E7 /* socialwindow.cpp */,
+				FC047AEA151E4FF700C5E9E7 /* socialwindow.h */,
+				FC047AEB151E4FF700C5E9E7 /* specialswindow.cpp */,
+				FC047AEC151E4FF700C5E9E7 /* specialswindow.h */,
+				FC047AED151E4FF700C5E9E7 /* speechbubble.cpp */,
+				FC047AEE151E4FF700C5E9E7 /* speechbubble.h */,
+				FC047AEF151E4FF700C5E9E7 /* statuswindow.cpp */,
+				FC047AF0151E4FF700C5E9E7 /* statuswindow.h */,
+				FC047AF1151E4FF700C5E9E7 /* textdialog.cpp */,
+				FC047AF2151E4FF700C5E9E7 /* textdialog.h */,
+				FC047AF3151E4FF700C5E9E7 /* textpopup.cpp */,
+				FC047AF4151E4FF700C5E9E7 /* textpopup.h */,
+				FC047AF5151E4FF700C5E9E7 /* tradewindow.cpp */,
+				FC047AF6151E4FF700C5E9E7 /* tradewindow.h */,
+				FC047AF7151E4FF700C5E9E7 /* truetypefont.cpp */,
+				FC047AF8151E4FF700C5E9E7 /* truetypefont.h */,
+				FC047AF9151E4FF700C5E9E7 /* unregisterdialog.cpp */,
+				FC047AFA151E4FF700C5E9E7 /* unregisterdialog.h */,
+				FC047AFB151E4FF700C5E9E7 /* updaterwindow.cpp */,
+				FC047AFC151E4FF700C5E9E7 /* updaterwindow.h */,
+				FC047AFD151E4FF700C5E9E7 /* viewport.cpp */,
+				FC047AFE151E4FF700C5E9E7 /* viewport.h */,
+				FC047AFF151E4FF700C5E9E7 /* widgets */,
+				FC047B5B151E4FF700C5E9E7 /* windowmenu.cpp */,
+				FC047B5C151E4FF700C5E9E7 /* windowmenu.h */,
+				FC047B5D151E4FF700C5E9E7 /* worldselectdialog.cpp */,
+				FC047B5E151E4FF700C5E9E7 /* worldselectdialog.h */,
+			);
+			name = gui;
+			path = ../../src/gui;
+			sourceTree = "<group>";
+		};
+		FC047AFF151E4FF700C5E9E7 /* widgets */ = {
+			isa = PBXGroup;
+			children = (
+				FC047B00151E4FF700C5E9E7 /* avatarlistbox.cpp */,
+				FC047B01151E4FF700C5E9E7 /* avatarlistbox.h */,
+				FC047B02151E4FF700C5E9E7 /* browserbox.cpp */,
+				FC047B03151E4FF700C5E9E7 /* browserbox.h */,
+				FC047B04151E4FF700C5E9E7 /* button.cpp */,
+				FC047B05151E4FF700C5E9E7 /* button.h */,
+				FC047B06151E4FF700C5E9E7 /* channeltab.cpp */,
+				FC047B07151E4FF700C5E9E7 /* channeltab.h */,
+				FC047B08151E4FF700C5E9E7 /* chattab.cpp */,
+				FC047B09151E4FF700C5E9E7 /* chattab.h */,
+				FC047B0A151E4FF700C5E9E7 /* checkbox.cpp */,
+				FC047B0B151E4FF700C5E9E7 /* checkbox.h */,
+				FC047B0C151E4FF700C5E9E7 /* container.cpp */,
+				FC047B0D151E4FF700C5E9E7 /* container.h */,
+				FC047B0E151E4FF700C5E9E7 /* desktop.cpp */,
+				FC047B0F151E4FF700C5E9E7 /* desktop.h */,
+				FC047B10151E4FF700C5E9E7 /* dropdown.cpp */,
+				FC047B11151E4FF700C5E9E7 /* dropdown.h */,
+				FC047B12151E4FF700C5E9E7 /* emoteshortcutcontainer.cpp */,
+				FC047B13151E4FF700C5E9E7 /* emoteshortcutcontainer.h */,
+				FC047B14151E4FF700C5E9E7 /* flowcontainer.cpp */,
+				FC047B15151E4FF700C5E9E7 /* flowcontainer.h */,
+				FC047B16151E4FF700C5E9E7 /* icon.cpp */,
+				FC047B17151E4FF700C5E9E7 /* icon.h */,
+				FC047B18151E4FF700C5E9E7 /* inttextfield.cpp */,
+				FC047B19151E4FF700C5E9E7 /* inttextfield.h */,
+				FC047B1A151E4FF700C5E9E7 /* itemcontainer.cpp */,
+				FC047B1B151E4FF700C5E9E7 /* itemcontainer.h */,
+				FC047B1C151E4FF700C5E9E7 /* itemlinkhandler.cpp */,
+				FC047B1D151E4FF700C5E9E7 /* itemlinkhandler.h */,
+				FC047B1E151E4FF700C5E9E7 /* itemshortcutcontainer.cpp */,
+				FC047B1F151E4FF700C5E9E7 /* itemshortcutcontainer.h */,
+				FC047B20151E4FF700C5E9E7 /* label.cpp */,
+				FC047B21151E4FF700C5E9E7 /* label.h */,
+				FC047B22151E4FF700C5E9E7 /* layout.cpp */,
+				FC047B23151E4FF700C5E9E7 /* layout.h */,
+				FC047B24151E4FF700C5E9E7 /* layouthelper.cpp */,
+				FC047B25151E4FF700C5E9E7 /* layouthelper.h */,
+				FC047B26151E4FF700C5E9E7 /* linkhandler.h */,
+				FC047B27151E4FF700C5E9E7 /* listbox.cpp */,
+				FC047B28151E4FF700C5E9E7 /* listbox.h */,
+				FC047B29151E4FF700C5E9E7 /* passwordfield.cpp */,
+				FC047B2A151E4FF700C5E9E7 /* passwordfield.h */,
+				FC047B2B151E4FF700C5E9E7 /* playerbox.cpp */,
+				FC047B2C151E4FF700C5E9E7 /* playerbox.h */,
+				FC047B2D151E4FF700C5E9E7 /* popup.cpp */,
+				FC047B2E151E4FF700C5E9E7 /* popup.h */,
+				FC047B2F151E4FF700C5E9E7 /* progressbar.cpp */,
+				FC047B30151E4FF700C5E9E7 /* progressbar.h */,
+				FC047B31151E4FF700C5E9E7 /* progressindicator.cpp */,
+				FC047B32151E4FF700C5E9E7 /* progressindicator.h */,
+				FC047B33151E4FF700C5E9E7 /* radiobutton.cpp */,
+				FC047B34151E4FF700C5E9E7 /* radiobutton.h */,
+				FC047B35151E4FF700C5E9E7 /* resizegrip.cpp */,
+				FC047B36151E4FF700C5E9E7 /* resizegrip.h */,
+				FC047B37151E4FF700C5E9E7 /* scrollarea.cpp */,
+				FC047B38151E4FF700C5E9E7 /* scrollarea.h */,
+				FC047B39151E4FF700C5E9E7 /* setuptab.cpp */,
+				FC047B3A151E4FF700C5E9E7 /* setuptab.h */,
+				FC047B3B151E4FF700C5E9E7 /* shopitems.cpp */,
+				FC047B3C151E4FF700C5E9E7 /* shopitems.h */,
+				FC047B3D151E4FF700C5E9E7 /* shoplistbox.cpp */,
+				FC047B3E151E4FF700C5E9E7 /* shoplistbox.h */,
+				FC047B3F151E4FF700C5E9E7 /* shortcutcontainer.cpp */,
+				FC047B40151E4FF700C5E9E7 /* shortcutcontainer.h */,
+				FC047B41151E4FF700C5E9E7 /* slider.cpp */,
+				FC047B42151E4FF700C5E9E7 /* slider.h */,
+				FC047B43151E4FF700C5E9E7 /* spacer.cpp */,
+				FC047B44151E4FF700C5E9E7 /* spacer.h */,
+				FC047B45151E4FF700C5E9E7 /* tab.cpp */,
+				FC047B46151E4FF700C5E9E7 /* tab.h */,
+				FC047B47151E4FF700C5E9E7 /* tabbedarea.cpp */,
+				FC047B48151E4FF700C5E9E7 /* tabbedarea.h */,
+				FC047B49151E4FF700C5E9E7 /* table.cpp */,
+				FC047B4A151E4FF700C5E9E7 /* table.h */,
+				FC047B4B151E4FF700C5E9E7 /* tablemodel.cpp */,
+				FC047B4C151E4FF700C5E9E7 /* tablemodel.h */,
+				FC047B4D151E4FF700C5E9E7 /* textbox.cpp */,
+				FC047B4E151E4FF700C5E9E7 /* textbox.h */,
+				FC047B4F151E4FF700C5E9E7 /* textfield.cpp */,
+				FC047B50151E4FF700C5E9E7 /* textfield.h */,
+				FC047B51151E4FF700C5E9E7 /* textpreview.cpp */,
+				FC047B52151E4FF700C5E9E7 /* textpreview.h */,
+				FC047B53151E4FF700C5E9E7 /* vertcontainer.cpp */,
+				FC047B54151E4FF700C5E9E7 /* vertcontainer.h */,
+				FC047B55151E4FF700C5E9E7 /* whispertab.cpp */,
+				FC047B56151E4FF700C5E9E7 /* whispertab.h */,
+				FC047B57151E4FF700C5E9E7 /* window.cpp */,
+				FC047B58151E4FF700C5E9E7 /* window.h */,
+				FC047B59151E4FF700C5E9E7 /* windowcontainer.cpp */,
+				FC047B5A151E4FF700C5E9E7 /* windowcontainer.h */,
+			);
+			path = widgets;
+			sourceTree = "<group>";
+		};
+		FC047BC6151E500100C5E9E7 /* net */ = {
+			isa = PBXGroup;
+			children = (
+				FC047BC7151E500100C5E9E7 /* adminhandler.h */,
+				FC047BC8151E500100C5E9E7 /* charhandler.cpp */,
+				FC047BC9151E500100C5E9E7 /* charhandler.h */,
+				FC047BCA151E500100C5E9E7 /* chathandler.h */,
+				FC047BCB151E500100C5E9E7 /* download.cpp */,
+				FC047BCC151E500100C5E9E7 /* download.h */,
+				FC047BCD151E500100C5E9E7 /* gamehandler.h */,
+				FC047BCE151E500100C5E9E7 /* generalhandler.h */,
+				FC047BCF151E500100C5E9E7 /* guildhandler.h */,
+				FC047BD0151E500100C5E9E7 /* inventoryhandler.h */,
+				FC047BD1151E500100C5E9E7 /* logindata.h */,
+				FC047BD2151E500100C5E9E7 /* loginhandler.h */,
+				FC047BD3151E500100C5E9E7 /* manaserv */,
+				FC047C06151E500100C5E9E7 /* messagehandler.h */,
+				FC047C0B151E500100C5E9E7 /* net.cpp */,
+				FC047C0C151E500100C5E9E7 /* net.h */,
+				FC047C0D151E500100C5E9E7 /* npchandler.h */,
+				FC047C0E151E500100C5E9E7 /* partyhandler.h */,
+				FC047C0F151E500100C5E9E7 /* playerhandler.h */,
+				FC047C10151E500100C5E9E7 /* serverinfo.h */,
+				FC047C11151E500100C5E9E7 /* specialhandler.h */,
+				FC047C12151E500100C5E9E7 /* tmwa */,
+				FC047C42151E500100C5E9E7 /* tradehandler.h */,
+				FC047C43151E500100C5E9E7 /* worldinfo.h */,
+			);
+			name = net;
+			path = ../../src/net;
+			sourceTree = "<group>";
+		};
+		FC047BD3151E500100C5E9E7 /* manaserv */ = {
+			isa = PBXGroup;
+			children = (
+				FC047BD4151E500100C5E9E7 /* adminhandler.cpp */,
+				FC047BD5151E500100C5E9E7 /* adminhandler.h */,
+				FC047BD6151E500100C5E9E7 /* attributes.cpp */,
+				FC047BD7151E500100C5E9E7 /* attributes.h */,
+				FC047BD8151E500100C5E9E7 /* beinghandler.cpp */,
+				FC047BD9151E500100C5E9E7 /* beinghandler.h */,
+				FC047BDA151E500100C5E9E7 /* buysellhandler.cpp */,
+				FC047BDB151E500100C5E9E7 /* buysellhandler.h */,
+				FC047BDC151E500100C5E9E7 /* charhandler.cpp */,
+				FC047BDD151E500100C5E9E7 /* charhandler.h */,
+				FC047BDE151E500100C5E9E7 /* chathandler.cpp */,
+				FC047BDF151E500100C5E9E7 /* chathandler.h */,
+				FC047BE0151E500100C5E9E7 /* connection.cpp */,
+				FC047BE1151E500100C5E9E7 /* connection.h */,
+				FC047BE2151E500100C5E9E7 /* defines.h */,
+				FC047BE3151E500100C5E9E7 /* effecthandler.cpp */,
+				FC047BE4151E500100C5E9E7 /* effecthandler.h */,
+				FC047BE5151E500100C5E9E7 /* gamehandler.cpp */,
+				FC047BE6151E500100C5E9E7 /* gamehandler.h */,
+				FC047BE7151E500100C5E9E7 /* generalhandler.cpp */,
+				FC047BE8151E500100C5E9E7 /* generalhandler.h */,
+				FC047BE9151E500100C5E9E7 /* guildhandler.cpp */,
+				FC047BEA151E500100C5E9E7 /* guildhandler.h */,
+				FC047BEB151E500100C5E9E7 /* internal.cpp */,
+				FC047BEC151E500100C5E9E7 /* internal.h */,
+				FC047BED151E500100C5E9E7 /* inventoryhandler.cpp */,
+				FC047BEE151E500100C5E9E7 /* inventoryhandler.h */,
+				FC047BEF151E500100C5E9E7 /* itemhandler.cpp */,
+				FC047BF0151E500100C5E9E7 /* itemhandler.h */,
+				FC047BF1151E500100C5E9E7 /* loginhandler.cpp */,
+				FC047BF2151E500100C5E9E7 /* loginhandler.h */,
+				FC047BF3151E500100C5E9E7 /* manaserv_protocol.h */,
+				FC047BF4151E500100C5E9E7 /* messagehandler.cpp */,
+				FC047BF5151E500100C5E9E7 /* messagehandler.h */,
+				FC047BF6151E500100C5E9E7 /* messagein.cpp */,
+				FC047BF7151E500100C5E9E7 /* messagein.h */,
+				FC047BF8151E500100C5E9E7 /* messageout.cpp */,
+				FC047BF9151E500100C5E9E7 /* messageout.h */,
+				FC047BFA151E500100C5E9E7 /* network.cpp */,
+				FC047BFB151E500100C5E9E7 /* network.h */,
+				FC047BFC151E500100C5E9E7 /* npchandler.cpp */,
+				FC047BFD151E500100C5E9E7 /* npchandler.h */,
+				FC047BFE151E500100C5E9E7 /* partyhandler.cpp */,
+				FC047BFF151E500100C5E9E7 /* partyhandler.h */,
+				FC047C00151E500100C5E9E7 /* playerhandler.cpp */,
+				FC047C01151E500100C5E9E7 /* playerhandler.h */,
+				FC047C02151E500100C5E9E7 /* specialhandler.cpp */,
+				FC047C03151E500100C5E9E7 /* specialhandler.h */,
+				FC047C04151E500100C5E9E7 /* tradehandler.cpp */,
+				FC047C05151E500100C5E9E7 /* tradehandler.h */,
+			);
+			path = manaserv;
+			sourceTree = "<group>";
+		};
+		FC047C12151E500100C5E9E7 /* tmwa */ = {
+			isa = PBXGroup;
+			children = (
+				FC047C13151E500100C5E9E7 /* adminhandler.cpp */,
+				FC047C14151E500100C5E9E7 /* adminhandler.h */,
+				FC047C15151E500100C5E9E7 /* beinghandler.cpp */,
+				FC047C16151E500100C5E9E7 /* beinghandler.h */,
+				FC047C17151E500100C5E9E7 /* buysellhandler.cpp */,
+				FC047C18151E500100C5E9E7 /* buysellhandler.h */,
+				FC047C19151E500100C5E9E7 /* charserverhandler.cpp */,
+				FC047C1A151E500100C5E9E7 /* charserverhandler.h */,
+				FC047C1B151E500100C5E9E7 /* chathandler.cpp */,
+				FC047C1C151E500100C5E9E7 /* chathandler.h */,
+				FC047C1D151E500100C5E9E7 /* gamehandler.cpp */,
+				FC047C1E151E500100C5E9E7 /* gamehandler.h */,
+				FC047C1F151E500100C5E9E7 /* generalhandler.cpp */,
+				FC047C20151E500100C5E9E7 /* generalhandler.h */,
+				FC047C21151E500100C5E9E7 /* gui */,
+				FC047C26151E500100C5E9E7 /* guildhandler.cpp */,
+				FC047C27151E500100C5E9E7 /* guildhandler.h */,
+				FC047C28151E500100C5E9E7 /* inventoryhandler.cpp */,
+				FC047C29151E500100C5E9E7 /* inventoryhandler.h */,
+				FC047C2A151E500100C5E9E7 /* itemhandler.cpp */,
+				FC047C2B151E500100C5E9E7 /* itemhandler.h */,
+				FC047C2C151E500100C5E9E7 /* loginhandler.cpp */,
+				FC047C2D151E500100C5E9E7 /* loginhandler.h */,
+				FC047C2E151E500100C5E9E7 /* messagehandler.cpp */,
+				FC047C2F151E500100C5E9E7 /* messagehandler.h */,
+				FC047C30151E500100C5E9E7 /* messagein.cpp */,
+				FC047C31151E500100C5E9E7 /* messagein.h */,
+				FC047C32151E500100C5E9E7 /* messageout.cpp */,
+				FC047C33151E500100C5E9E7 /* messageout.h */,
+				FC047C34151E500100C5E9E7 /* network.cpp */,
+				FC047C35151E500100C5E9E7 /* network.h */,
+				FC047C36151E500100C5E9E7 /* npchandler.cpp */,
+				FC047C37151E500100C5E9E7 /* npchandler.h */,
+				FC047C38151E500100C5E9E7 /* partyhandler.cpp */,
+				FC047C39151E500100C5E9E7 /* partyhandler.h */,
+				FC047C3A151E500100C5E9E7 /* playerhandler.cpp */,
+				FC047C3B151E500100C5E9E7 /* playerhandler.h */,
+				FC047C3C151E500100C5E9E7 /* protocol.h */,
+				FC047C3D151E500100C5E9E7 /* specialhandler.cpp */,
+				FC047C3E151E500100C5E9E7 /* specialhandler.h */,
+				FC047C3F151E500100C5E9E7 /* token.h */,
+				FC047C40151E500100C5E9E7 /* tradehandler.cpp */,
+				FC047C41151E500100C5E9E7 /* tradehandler.h */,
+			);
+			path = tmwa;
+			sourceTree = "<group>";
+		};
+		FC047C21151E500100C5E9E7 /* gui */ = {
+			isa = PBXGroup;
+			children = (
+				FC047C22151E500100C5E9E7 /* guildtab.cpp */,
+				FC047C23151E500100C5E9E7 /* guildtab.h */,
+				FC047C24151E500100C5E9E7 /* partytab.cpp */,
+				FC047C25151E500100C5E9E7 /* partytab.h */,
+			);
+			path = gui;
+			sourceTree = "<group>";
+		};
+		FC047C77151E500C00C5E9E7 /* resources */ = {
+			isa = PBXGroup;
+			children = (
+				FC047C78151E500C00C5E9E7 /* action.cpp */,
+				FC047C79151E500C00C5E9E7 /* action.h */,
+				FC047C7A151E500C00C5E9E7 /* ambientlayer.cpp */,
+				FC047C7B151E500C00C5E9E7 /* ambientlayer.h */,
+				FC047C7C151E500C00C5E9E7 /* animation.cpp */,
+				FC047C7D151E500C00C5E9E7 /* animation.h */,
+				FC047C7E151E500C00C5E9E7 /* beinginfo.cpp */,
+				FC047C7F151E500C00C5E9E7 /* beinginfo.h */,
+				FC047C80151E500C00C5E9E7 /* dye.cpp */,
+				FC047C81151E500C00C5E9E7 /* dye.h */,
+				FC047C82151E500C00C5E9E7 /* emotedb.cpp */,
+				FC047C83151E500C00C5E9E7 /* emotedb.h */,
+				FC047C84151E500C00C5E9E7 /* hairdb.cpp */,
+				FC047C85151E500C00C5E9E7 /* hairdb.h */,
+				FC047C86151E500C00C5E9E7 /* image.cpp */,
+				FC047C87151E500C00C5E9E7 /* image.h */,
+				FC047C88151E500C00C5E9E7 /* imageloader.cpp */,
+				FC047C89151E500C00C5E9E7 /* imageloader.h */,
+				FC047C8A151E500C00C5E9E7 /* imageset.cpp */,
+				FC047C8B151E500C00C5E9E7 /* imageset.h */,
+				FC047C8C151E500C00C5E9E7 /* imagewriter.cpp */,
+				FC047C8D151E500C00C5E9E7 /* imagewriter.h */,
+				FC047C8E151E500C00C5E9E7 /* itemdb.cpp */,
+				FC047C8F151E500C00C5E9E7 /* itemdb.h */,
+				FC047C90151E500C00C5E9E7 /* iteminfo.cpp */,
+				FC047C91151E500C00C5E9E7 /* iteminfo.h */,
+				FC047C92151E500C00C5E9E7 /* mapreader.cpp */,
+				FC047C93151E500C00C5E9E7 /* mapreader.h */,
+				FC047C94151E500C00C5E9E7 /* monsterdb.cpp */,
+				FC047C95151E500C00C5E9E7 /* monsterdb.h */,
+				FC047C96151E500C00C5E9E7 /* music.cpp */,
+				FC047C97151E500C00C5E9E7 /* music.h */,
+				FC047C98151E500C00C5E9E7 /* npcdb.cpp */,
+				FC047C99151E500C00C5E9E7 /* npcdb.h */,
+				FC047C9A151E500C00C5E9E7 /* resource.cpp */,
+				FC047C9B151E500C00C5E9E7 /* resource.h */,
+				FC047C9C151E500C00C5E9E7 /* resourcemanager.cpp */,
+				FC047C9D151E500C00C5E9E7 /* resourcemanager.h */,
+				FC047C9E151E500C00C5E9E7 /* soundeffect.cpp */,
+				FC047C9F151E500C00C5E9E7 /* soundeffect.h */,
+				FC047CA0151E500C00C5E9E7 /* specialdb.cpp */,
+				FC047CA1151E500C00C5E9E7 /* specialdb.h */,
+				FC047CA2151E500C00C5E9E7 /* spritedef.cpp */,
+				FC047CA3151E500C00C5E9E7 /* spritedef.h */,
+				FC047CA4151E500C00C5E9E7 /* theme.cpp */,
+				FC047CA5151E500C00C5E9E7 /* theme.h */,
+				FC047CA6151E500C00C5E9E7 /* userpalette.cpp */,
+				FC047CA7151E500C00C5E9E7 /* userpalette.h */,
+				FC047CA8151E500C00C5E9E7 /* wallpaper.cpp */,
+				FC047CA9151E500C00C5E9E7 /* wallpaper.h */,
+			);
+			name = resources;
+			path = ../../src/resources;
+			sourceTree = "<group>";
+		};
+		FC047CC3151E501400C5E9E7 /* utils */ = {
+			isa = PBXGroup;
+			children = (
+				FC047CC4151E501400C5E9E7 /* base64.cpp */,
+				FC047CC5151E501400C5E9E7 /* base64.h */,
+				FC047CC6151E501400C5E9E7 /* copynpaste.cpp */,
+				FC047CC7151E501400C5E9E7 /* copynpaste.h */,
+				FC047CC8151E501400C5E9E7 /* dtor.h */,
+				FC047CC9151E501400C5E9E7 /* gettext.h */,
+				FC047CCA151E501400C5E9E7 /* mathutils.h */,
+				FC047CCB151E501400C5E9E7 /* mkdir.cpp */,
+				FC047CCC151E501400C5E9E7 /* mkdir.h */,
+				FC047CCD151E501400C5E9E7 /* mutex.h */,
+				FC047CCE151E501400C5E9E7 /* physfsrwops.c */,
+				FC047CCF151E501400C5E9E7 /* physfsrwops.h */,
+				FC047CD0151E501400C5E9E7 /* sha256.cpp */,
+				FC047CD1151E501400C5E9E7 /* sha256.h */,
+				FC047CD2151E501400C5E9E7 /* specialfolder.cpp */,
+				FC047CD3151E501400C5E9E7 /* specialfolder.h */,
+				FC047CD4151E501400C5E9E7 /* stringutils.cpp */,
+				FC047CD5151E501400C5E9E7 /* stringutils.h */,
+				FC047CD6151E501400C5E9E7 /* xml.cpp */,
+				FC047CD7151E501400C5E9E7 /* xml.h */,
+				FC047CD8151E501400C5E9E7 /* zlib.cpp */,
+				FC047CD9151E501400C5E9E7 /* zlib.h */,
+			);
+			name = utils;
+			path = ../../src/utils;
+			sourceTree = "<group>";
+		};
+		FC047CE7151E7C8500C5E9E7 /* cpp0x_compat */ = {
+			isa = PBXGroup;
+			children = (
+				FC047CE8151E7C8500C5E9E7 /* cstdint */,
+			);
+			name = cpp0x_compat;
+			path = ../../src/cpp0x_compat;
+			sourceTree = "<group>";
+		};
+		FC047CEA151E820000C5E9E7 /* enet */ = {
+			isa = PBXGroup;
+			children = (
+				FC047CEB151E820000C5E9E7 /* callbacks.c */,
+				FC047CEE151E820000C5E9E7 /* compress.c */,
+				FC047CF0151E820000C5E9E7 /* host.c */,
+				FC047CF1151E820000C5E9E7 /* include */,
+				FC047CFD151E820000C5E9E7 /* list.c */,
+				FC047CFE151E820000C5E9E7 /* packet.c */,
+				FC047CFF151E820000C5E9E7 /* peer.c */,
+				FC047D00151E820000C5E9E7 /* protocol.c */,
+				FC047D02151E820000C5E9E7 /* unix.c */,
+			);
+			name = enet;
+			path = ../../libs/enet;
+			sourceTree = "<group>";
+		};
+		FC047CF1151E820000C5E9E7 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				FC047CF2151E820000C5E9E7 /* enet */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		FC047CF2151E820000C5E9E7 /* enet */ = {
+			isa = PBXGroup;
+			children = (
+				FC047CF3151E820000C5E9E7 /* callbacks.h */,
+				FC047CF4151E820000C5E9E7 /* enet.h */,
+				FC047CF5151E820000C5E9E7 /* list.h */,
+				FC047CF6151E820000C5E9E7 /* protocol.h */,
+				FC047CF7151E820000C5E9E7 /* time.h */,
+				FC047CF8151E820000C5E9E7 /* types.h */,
+				FC047CF9151E820000C5E9E7 /* unix.h */,
+				FC047CFA151E820000C5E9E7 /* utility.h */,
+				FC047CFB151E820000C5E9E7 /* win32.h */,
+			);
+			path = enet;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		FC0479C5151E4DB700C5E9E7 /* mana */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FC0479E4151E4DB800C5E9E7 /* Build configuration list for PBXNativeTarget "mana" */;
+			buildPhases = (
+				FC0479C2151E4DB700C5E9E7 /* Sources */,
+				FC0479C3151E4DB700C5E9E7 /* Frameworks */,
+				FC0479C4151E4DB700C5E9E7 /* Resources */,
+				FC047D32151E920100C5E9E7 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = mana;
+			productName = mana;
+			productReference = FC0479C6151E4DB700C5E9E7 /* mana.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		FC0479BD151E4DB700C5E9E7 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0430;
+			};
+			buildConfigurationList = FC0479C0151E4DB700C5E9E7 /* Build configuration list for PBXProject "mana10.7" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = FC0479BB151E4DB700C5E9E7;
+			productRefGroup = FC0479C7151E4DB700C5E9E7 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				FC0479C5151E4DB700C5E9E7 /* mana */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		FC0479C4151E4DB700C5E9E7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC0479D5151E4DB700C5E9E7 /* InfoPlist.strings in Resources */,
+				FC0479E1151E4DB800C5E9E7 /* MainMenu.xib in Resources */,
+				FC047CE9151E7C8500C5E9E7 /* cstdint in Resources */,
+				FC047D31151E8F8200C5E9E7 /* data in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		FC0479C2151E4DB700C5E9E7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC047A13151E4F8800C5E9E7 /* actor.cpp in Sources */,
+				FC047A14151E4F8800C5E9E7 /* actorsprite.cpp in Sources */,
+				FC047A15151E4F8800C5E9E7 /* actorspritemanager.cpp in Sources */,
+				FC047A16151E4F8800C5E9E7 /* animatedsprite.cpp in Sources */,
+				FC047A17151E4F8800C5E9E7 /* animationparticle.cpp in Sources */,
+				FC047A18151E4F8800C5E9E7 /* avatar.cpp in Sources */,
+				FC047A19151E4F8800C5E9E7 /* being.cpp in Sources */,
+				FC047A1A151E4F8800C5E9E7 /* channel.cpp in Sources */,
+				FC047A1B151E4F8800C5E9E7 /* channelmanager.cpp in Sources */,
+				FC047A1C151E4F8800C5E9E7 /* chatlogger.cpp in Sources */,
+				FC047A1D151E4F8800C5E9E7 /* client.cpp in Sources */,
+				FC047A1E151E4F8800C5E9E7 /* commandhandler.cpp in Sources */,
+				FC047A1F151E4F8800C5E9E7 /* compoundsprite.cpp in Sources */,
+				FC047A20151E4F8800C5E9E7 /* configuration.cpp in Sources */,
+				FC047A21151E4F8800C5E9E7 /* defaults.cpp in Sources */,
+				FC047A22151E4F8800C5E9E7 /* effectmanager.cpp in Sources */,
+				FC047A23151E4F8800C5E9E7 /* emoteshortcut.cpp in Sources */,
+				FC047A24151E4F8800C5E9E7 /* event.cpp in Sources */,
+				FC047A25151E4F8800C5E9E7 /* eventlistener.cpp in Sources */,
+				FC047A26151E4F8800C5E9E7 /* flooritem.cpp in Sources */,
+				FC047A27151E4F8800C5E9E7 /* game.cpp in Sources */,
+				FC047A28151E4F8800C5E9E7 /* graphics.cpp in Sources */,
+				FC047A6F151E4FC700C5E9E7 /* guild.cpp in Sources */,
+				FC047A70151E4FC700C5E9E7 /* imageparticle.cpp in Sources */,
+				FC047A71151E4FC700C5E9E7 /* imagesprite.cpp in Sources */,
+				FC047A72151E4FC700C5E9E7 /* inventory.cpp in Sources */,
+				FC047A73151E4FC700C5E9E7 /* item.cpp in Sources */,
+				FC047A74151E4FC700C5E9E7 /* itemshortcut.cpp in Sources */,
+				FC047A75151E4FC700C5E9E7 /* joystick.cpp in Sources */,
+				FC047A76151E4FC700C5E9E7 /* keyboardconfig.cpp in Sources */,
+				FC047A77151E4FC700C5E9E7 /* localplayer.cpp in Sources */,
+				FC047A78151E4FC700C5E9E7 /* log.cpp in Sources */,
+				FC047A79151E4FC700C5E9E7 /* main.cpp in Sources */,
+				FC047A7A151E4FC700C5E9E7 /* map.cpp in Sources */,
+				FC047A7B151E4FC700C5E9E7 /* openglgraphics.cpp in Sources */,
+				FC047A7C151E4FC700C5E9E7 /* particle.cpp in Sources */,
+				FC047A7D151E4FC700C5E9E7 /* particlecontainer.cpp in Sources */,
+				FC047A7E151E4FC700C5E9E7 /* particleemitter.cpp in Sources */,
+				FC047A7F151E4FC700C5E9E7 /* party.cpp in Sources */,
+				FC047A80151E4FC700C5E9E7 /* playerinfo.cpp in Sources */,
+				FC047A81151E4FC700C5E9E7 /* playerrelations.cpp in Sources */,
+				FC047A82151E4FC700C5E9E7 /* position.cpp in Sources */,
+				FC047A83151E4FC700C5E9E7 /* rotationalparticle.cpp in Sources */,
+				FC047A84151E4FC700C5E9E7 /* SDLMain.m in Sources */,
+				FC047A85151E4FC700C5E9E7 /* shopitem.cpp in Sources */,
+				FC047A86151E4FC700C5E9E7 /* simpleanimation.cpp in Sources */,
+				FC047A87151E4FC700C5E9E7 /* sound.cpp in Sources */,
+				FC047A88151E4FC700C5E9E7 /* statuseffect.cpp in Sources */,
+				FC047A89151E4FC700C5E9E7 /* text.cpp in Sources */,
+				FC047A8A151E4FC700C5E9E7 /* textmanager.cpp in Sources */,
+				FC047A8B151E4FC700C5E9E7 /* textparticle.cpp in Sources */,
+				FC047A8C151E4FC700C5E9E7 /* units.cpp in Sources */,
+				FC047A8D151E4FC700C5E9E7 /* vector.cpp in Sources */,
+				FC047B5F151E4FF700C5E9E7 /* beingpopup.cpp in Sources */,
+				FC047B60151E4FF700C5E9E7 /* buydialog.cpp in Sources */,
+				FC047B61151E4FF700C5E9E7 /* buyselldialog.cpp in Sources */,
+				FC047B62151E4FF700C5E9E7 /* changeemaildialog.cpp in Sources */,
+				FC047B63151E4FF700C5E9E7 /* changepassworddialog.cpp in Sources */,
+				FC047B64151E4FF700C5E9E7 /* charcreatedialog.cpp in Sources */,
+				FC047B65151E4FF700C5E9E7 /* charselectdialog.cpp in Sources */,
+				FC047B66151E4FF700C5E9E7 /* chatwindow.cpp in Sources */,
+				FC047B67151E4FF700C5E9E7 /* confirmdialog.cpp in Sources */,
+				FC047B68151E4FF700C5E9E7 /* connectiondialog.cpp in Sources */,
+				FC047B69151E4FF700C5E9E7 /* customserverdialog.cpp in Sources */,
+				FC047B6A151E4FF700C5E9E7 /* debugwindow.cpp in Sources */,
+				FC047B6B151E4FF700C5E9E7 /* emotepopup.cpp in Sources */,
+				FC047B6C151E4FF700C5E9E7 /* equipmentwindow.cpp in Sources */,
+				FC047B6D151E4FF700C5E9E7 /* focushandler.cpp in Sources */,
+				FC047B6E151E4FF700C5E9E7 /* gui.cpp in Sources */,
+				FC047B6F151E4FF700C5E9E7 /* helpwindow.cpp in Sources */,
+				FC047B70151E4FF700C5E9E7 /* inventorywindow.cpp in Sources */,
+				FC047B71151E4FF700C5E9E7 /* itemamountwindow.cpp in Sources */,
+				FC047B72151E4FF700C5E9E7 /* itempopup.cpp in Sources */,
+				FC047B73151E4FF700C5E9E7 /* logindialog.cpp in Sources */,
+				FC047B74151E4FF700C5E9E7 /* minimap.cpp in Sources */,
+				FC047B75151E4FF700C5E9E7 /* ministatuswindow.cpp in Sources */,
+				FC047B76151E4FF700C5E9E7 /* npcdialog.cpp in Sources */,
+				FC047B77151E4FF700C5E9E7 /* npcpostdialog.cpp in Sources */,
+				FC047B78151E4FF700C5E9E7 /* okdialog.cpp in Sources */,
+				FC047B79151E4FF700C5E9E7 /* outfitwindow.cpp in Sources */,
+				FC047B7A151E4FF700C5E9E7 /* palette.cpp in Sources */,
+				FC047B7B151E4FF700C5E9E7 /* popupmenu.cpp in Sources */,
+				FC047B7C151E4FF700C5E9E7 /* quitdialog.cpp in Sources */,
+				FC047B7D151E4FF700C5E9E7 /* recorder.cpp in Sources */,
+				FC047B7E151E4FF700C5E9E7 /* register.cpp in Sources */,
+				FC047B7F151E4FF700C5E9E7 /* sdlinput.cpp in Sources */,
+				FC047B80151E4FF700C5E9E7 /* selldialog.cpp in Sources */,
+				FC047B81151E4FF700C5E9E7 /* serverdialog.cpp in Sources */,
+				FC047B82151E4FF700C5E9E7 /* setup.cpp in Sources */,
+				FC047B83151E4FF700C5E9E7 /* setup_audio.cpp in Sources */,
+				FC047B84151E4FF700C5E9E7 /* setup_colors.cpp in Sources */,
+				FC047B85151E4FF700C5E9E7 /* setup_interface.cpp in Sources */,
+				FC047B86151E4FF700C5E9E7 /* setup_joystick.cpp in Sources */,
+				FC047B87151E4FF700C5E9E7 /* setup_keyboard.cpp in Sources */,
+				FC047B88151E4FF700C5E9E7 /* setup_players.cpp in Sources */,
+				FC047B89151E4FF700C5E9E7 /* setup_video.cpp in Sources */,
+				FC047B8A151E4FF700C5E9E7 /* shortcutwindow.cpp in Sources */,
+				FC047B8B151E4FF700C5E9E7 /* skilldialog.cpp in Sources */,
+				FC047B8C151E4FF700C5E9E7 /* socialwindow.cpp in Sources */,
+				FC047B8D151E4FF700C5E9E7 /* specialswindow.cpp in Sources */,
+				FC047B8E151E4FF700C5E9E7 /* speechbubble.cpp in Sources */,
+				FC047B8F151E4FF700C5E9E7 /* statuswindow.cpp in Sources */,
+				FC047B90151E4FF700C5E9E7 /* textdialog.cpp in Sources */,
+				FC047B91151E4FF700C5E9E7 /* textpopup.cpp in Sources */,
+				FC047B92151E4FF700C5E9E7 /* tradewindow.cpp in Sources */,
+				FC047B93151E4FF700C5E9E7 /* truetypefont.cpp in Sources */,
+				FC047B94151E4FF700C5E9E7 /* unregisterdialog.cpp in Sources */,
+				FC047B95151E4FF700C5E9E7 /* updaterwindow.cpp in Sources */,
+				FC047B96151E4FF700C5E9E7 /* viewport.cpp in Sources */,
+				FC047B97151E4FF700C5E9E7 /* avatarlistbox.cpp in Sources */,
+				FC047B98151E4FF700C5E9E7 /* browserbox.cpp in Sources */,
+				FC047B99151E4FF700C5E9E7 /* button.cpp in Sources */,
+				FC047B9A151E4FF700C5E9E7 /* channeltab.cpp in Sources */,
+				FC047B9B151E4FF700C5E9E7 /* chattab.cpp in Sources */,
+				FC047B9C151E4FF700C5E9E7 /* checkbox.cpp in Sources */,
+				FC047B9D151E4FF700C5E9E7 /* container.cpp in Sources */,
+				FC047B9E151E4FF700C5E9E7 /* desktop.cpp in Sources */,
+				FC047B9F151E4FF700C5E9E7 /* dropdown.cpp in Sources */,
+				FC047BA0151E4FF700C5E9E7 /* emoteshortcutcontainer.cpp in Sources */,
+				FC047BA1151E4FF700C5E9E7 /* flowcontainer.cpp in Sources */,
+				FC047BA2151E4FF700C5E9E7 /* icon.cpp in Sources */,
+				FC047BA3151E4FF700C5E9E7 /* inttextfield.cpp in Sources */,
+				FC047BA4151E4FF700C5E9E7 /* itemcontainer.cpp in Sources */,
+				FC047BA5151E4FF700C5E9E7 /* itemlinkhandler.cpp in Sources */,
+				FC047BA6151E4FF700C5E9E7 /* itemshortcutcontainer.cpp in Sources */,
+				FC047BA7151E4FF700C5E9E7 /* label.cpp in Sources */,
+				FC047BA8151E4FF700C5E9E7 /* layout.cpp in Sources */,
+				FC047BA9151E4FF700C5E9E7 /* layouthelper.cpp in Sources */,
+				FC047BAA151E4FF700C5E9E7 /* listbox.cpp in Sources */,
+				FC047BAB151E4FF700C5E9E7 /* passwordfield.cpp in Sources */,
+				FC047BAC151E4FF700C5E9E7 /* playerbox.cpp in Sources */,
+				FC047BAD151E4FF700C5E9E7 /* popup.cpp in Sources */,
+				FC047BAE151E4FF700C5E9E7 /* progressbar.cpp in Sources */,
+				FC047BAF151E4FF700C5E9E7 /* progressindicator.cpp in Sources */,
+				FC047BB0151E4FF700C5E9E7 /* radiobutton.cpp in Sources */,
+				FC047BB1151E4FF700C5E9E7 /* resizegrip.cpp in Sources */,
+				FC047BB2151E4FF700C5E9E7 /* scrollarea.cpp in Sources */,
+				FC047BB3151E4FF700C5E9E7 /* setuptab.cpp in Sources */,
+				FC047BB4151E4FF700C5E9E7 /* shopitems.cpp in Sources */,
+				FC047BB5151E4FF700C5E9E7 /* shoplistbox.cpp in Sources */,
+				FC047BB6151E4FF700C5E9E7 /* shortcutcontainer.cpp in Sources */,
+				FC047BB7151E4FF700C5E9E7 /* slider.cpp in Sources */,
+				FC047BB8151E4FF700C5E9E7 /* spacer.cpp in Sources */,
+				FC047BB9151E4FF700C5E9E7 /* tab.cpp in Sources */,
+				FC047BBA151E4FF700C5E9E7 /* tabbedarea.cpp in Sources */,
+				FC047BBB151E4FF700C5E9E7 /* table.cpp in Sources */,
+				FC047BBC151E4FF700C5E9E7 /* tablemodel.cpp in Sources */,
+				FC047BBD151E4FF700C5E9E7 /* textbox.cpp in Sources */,
+				FC047BBE151E4FF700C5E9E7 /* textfield.cpp in Sources */,
+				FC047BBF151E4FF700C5E9E7 /* textpreview.cpp in Sources */,
+				FC047BC0151E4FF700C5E9E7 /* vertcontainer.cpp in Sources */,
+				FC047BC1151E4FF700C5E9E7 /* whispertab.cpp in Sources */,
+				FC047BC2151E4FF700C5E9E7 /* window.cpp in Sources */,
+				FC047BC3151E4FF700C5E9E7 /* windowcontainer.cpp in Sources */,
+				FC047BC4151E4FF700C5E9E7 /* windowmenu.cpp in Sources */,
+				FC047BC5151E4FF700C5E9E7 /* worldselectdialog.cpp in Sources */,
+				FC047C44151E500100C5E9E7 /* charhandler.cpp in Sources */,
+				FC047C45151E500100C5E9E7 /* download.cpp in Sources */,
+				FC047C46151E500100C5E9E7 /* adminhandler.cpp in Sources */,
+				FC047C47151E500100C5E9E7 /* attributes.cpp in Sources */,
+				FC047C48151E500100C5E9E7 /* beinghandler.cpp in Sources */,
+				FC047C49151E500100C5E9E7 /* buysellhandler.cpp in Sources */,
+				FC047C4A151E500100C5E9E7 /* charhandler.cpp in Sources */,
+				FC047C4B151E500100C5E9E7 /* chathandler.cpp in Sources */,
+				FC047C4C151E500100C5E9E7 /* connection.cpp in Sources */,
+				FC047C4D151E500100C5E9E7 /* effecthandler.cpp in Sources */,
+				FC047C4E151E500100C5E9E7 /* gamehandler.cpp in Sources */,
+				FC047C4F151E500100C5E9E7 /* generalhandler.cpp in Sources */,
+				FC047C50151E500100C5E9E7 /* guildhandler.cpp in Sources */,
+				FC047C51151E500100C5E9E7 /* internal.cpp in Sources */,
+				FC047C52151E500100C5E9E7 /* inventoryhandler.cpp in Sources */,
+				FC047C53151E500100C5E9E7 /* itemhandler.cpp in Sources */,
+				FC047C54151E500100C5E9E7 /* loginhandler.cpp in Sources */,
+				FC047C55151E500100C5E9E7 /* messagehandler.cpp in Sources */,
+				FC047C56151E500100C5E9E7 /* messagein.cpp in Sources */,
+				FC047C57151E500100C5E9E7 /* messageout.cpp in Sources */,
+				FC047C58151E500100C5E9E7 /* network.cpp in Sources */,
+				FC047C59151E500100C5E9E7 /* npchandler.cpp in Sources */,
+				FC047C5A151E500100C5E9E7 /* partyhandler.cpp in Sources */,
+				FC047C5B151E500100C5E9E7 /* playerhandler.cpp in Sources */,
+				FC047C5C151E500100C5E9E7 /* specialhandler.cpp in Sources */,
+				FC047C5D151E500100C5E9E7 /* tradehandler.cpp in Sources */,
+				FC047C60151E500100C5E9E7 /* net.cpp in Sources */,
+				FC047C61151E500100C5E9E7 /* adminhandler.cpp in Sources */,
+				FC047C62151E500100C5E9E7 /* beinghandler.cpp in Sources */,
+				FC047C63151E500100C5E9E7 /* buysellhandler.cpp in Sources */,
+				FC047C64151E500100C5E9E7 /* charserverhandler.cpp in Sources */,
+				FC047C65151E500100C5E9E7 /* chathandler.cpp in Sources */,
+				FC047C66151E500100C5E9E7 /* gamehandler.cpp in Sources */,
+				FC047C67151E500100C5E9E7 /* generalhandler.cpp in Sources */,
+				FC047C68151E500100C5E9E7 /* guildtab.cpp in Sources */,
+				FC047C69151E500100C5E9E7 /* partytab.cpp in Sources */,
+				FC047C6A151E500100C5E9E7 /* guildhandler.cpp in Sources */,
+				FC047C6B151E500100C5E9E7 /* inventoryhandler.cpp in Sources */,
+				FC047C6C151E500100C5E9E7 /* itemhandler.cpp in Sources */,
+				FC047C6D151E500100C5E9E7 /* loginhandler.cpp in Sources */,
+				FC047C6E151E500100C5E9E7 /* messagehandler.cpp in Sources */,
+				FC047C6F151E500100C5E9E7 /* messagein.cpp in Sources */,
+				FC047C70151E500100C5E9E7 /* messageout.cpp in Sources */,
+				FC047C71151E500100C5E9E7 /* network.cpp in Sources */,
+				FC047C72151E500100C5E9E7 /* npchandler.cpp in Sources */,
+				FC047C73151E500100C5E9E7 /* partyhandler.cpp in Sources */,
+				FC047C74151E500100C5E9E7 /* playerhandler.cpp in Sources */,
+				FC047C75151E500100C5E9E7 /* specialhandler.cpp in Sources */,
+				FC047C76151E500100C5E9E7 /* tradehandler.cpp in Sources */,
+				FC047CAA151E500C00C5E9E7 /* action.cpp in Sources */,
+				FC047CAB151E500C00C5E9E7 /* ambientlayer.cpp in Sources */,
+				FC047CAC151E500C00C5E9E7 /* animation.cpp in Sources */,
+				FC047CAD151E500C00C5E9E7 /* beinginfo.cpp in Sources */,
+				FC047CAE151E500C00C5E9E7 /* dye.cpp in Sources */,
+				FC047CAF151E500C00C5E9E7 /* emotedb.cpp in Sources */,
+				FC047CB0151E500C00C5E9E7 /* hairdb.cpp in Sources */,
+				FC047CB1151E500C00C5E9E7 /* image.cpp in Sources */,
+				FC047CB2151E500C00C5E9E7 /* imageloader.cpp in Sources */,
+				FC047CB3151E500C00C5E9E7 /* imageset.cpp in Sources */,
+				FC047CB4151E500C00C5E9E7 /* imagewriter.cpp in Sources */,
+				FC047CB5151E500C00C5E9E7 /* itemdb.cpp in Sources */,
+				FC047CB6151E500C00C5E9E7 /* iteminfo.cpp in Sources */,
+				FC047CB7151E500C00C5E9E7 /* mapreader.cpp in Sources */,
+				FC047CB8151E500C00C5E9E7 /* monsterdb.cpp in Sources */,
+				FC047CB9151E500C00C5E9E7 /* music.cpp in Sources */,
+				FC047CBA151E500C00C5E9E7 /* npcdb.cpp in Sources */,
+				FC047CBB151E500C00C5E9E7 /* resource.cpp in Sources */,
+				FC047CBC151E500C00C5E9E7 /* resourcemanager.cpp in Sources */,
+				FC047CBD151E500C00C5E9E7 /* soundeffect.cpp in Sources */,
+				FC047CBE151E500C00C5E9E7 /* specialdb.cpp in Sources */,
+				FC047CBF151E500C00C5E9E7 /* spritedef.cpp in Sources */,
+				FC047CC0151E500C00C5E9E7 /* theme.cpp in Sources */,
+				FC047CC1151E500C00C5E9E7 /* userpalette.cpp in Sources */,
+				FC047CC2151E500C00C5E9E7 /* wallpaper.cpp in Sources */,
+				FC047CDA151E501400C5E9E7 /* base64.cpp in Sources */,
+				FC047CDB151E501400C5E9E7 /* copynpaste.cpp in Sources */,
+				FC047CDC151E501400C5E9E7 /* mkdir.cpp in Sources */,
+				FC047CDD151E501400C5E9E7 /* physfsrwops.c in Sources */,
+				FC047CDE151E501400C5E9E7 /* sha256.cpp in Sources */,
+				FC047CDF151E501400C5E9E7 /* specialfolder.cpp in Sources */,
+				FC047CE0151E501400C5E9E7 /* stringutils.cpp in Sources */,
+				FC047CE1151E501400C5E9E7 /* xml.cpp in Sources */,
+				FC047CE2151E501400C5E9E7 /* zlib.cpp in Sources */,
+				FC047CE6151E747B00C5E9E7 /* log.mm in Sources */,
+				FC047D04151E820000C5E9E7 /* callbacks.c in Sources */,
+				FC047D07151E820000C5E9E7 /* compress.c in Sources */,
+				FC047D09151E820000C5E9E7 /* host.c in Sources */,
+				FC047D0B151E820000C5E9E7 /* list.c in Sources */,
+				FC047D0C151E820000C5E9E7 /* packet.c in Sources */,
+				FC047D0D151E820000C5E9E7 /* peer.c in Sources */,
+				FC047D0E151E820000C5E9E7 /* protocol.c in Sources */,
+				FC047D10151E820000C5E9E7 /* unix.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		FC0479D3151E4DB700C5E9E7 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FC0479D4151E4DB700C5E9E7 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		FC0479DF151E4DB800C5E9E7 /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FC0479E0151E4DB800C5E9E7 /* en */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		FC0479E2151E4DB800C5E9E7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					../src,
+					../src/cpp0x_compat,
+					../libs/enet/include,
+					/Library/Frameworks/SDL.framework/Headers,
+					/opt/local/include/libxml2,
+					/opt/local/include/SDL,
+					/opt/local/include,
+					/Library/Frameworks/SDL_mixer.framework/Headers,
+					/Library/Frameworks/SDL_image.framework/Headers,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					../libs,
+					/opt/local/lib,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-DHAS_SOCKLEN_T";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DWITH_OPENGL",
+					"-DENABLE_MANASERV",
+					"-DHAS_SOCKLEN_T",
+				);
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		FC0479E3151E4DB800C5E9E7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "VERSION=\"0.6.0\"";
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				"GCC_SYMBOLS_PRIVATE_EXTERN[arch=i386]" = NO;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					../src,
+					../src/cpp0x_compat,
+					../libs/enet/include,
+					/Library/Frameworks/SDL.framework/Headers,
+					/opt/local/include/libxml2,
+					/opt/local/include/SDL,
+					/opt/local/include,
+					/Library/Frameworks/SDL_mixer.framework/Headers,
+					/Library/Frameworks/SDL_image.framework/Headers,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					../libs,
+					/opt/local/lib,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-DHAS_SOCKLEN_T";
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-DWITH_OPENGL",
+					"-DENABLE_MANASERV",
+					"-DHAS_SOCKLEN_T",
+				);
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		FC0479E5151E4DB800C5E9E7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = /Library/Frameworks;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				GCC_PREFIX_HEADER = "";
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				HEADER_SEARCH_PATHS = (
+					../src,
+					../src/cpp0x_compat,
+					../libs/enet/include,
+					/Library/Frameworks/SDL.framework/Headers,
+					/opt/local/include/libxml2,
+					/opt/local/include/SDL,
+					/opt/local/include,
+					/Library/Frameworks/SDL_mixer.framework/Headers,
+					/Library/Frameworks/SDL_image.framework/Headers,
+				);
+				INFOPLIST_FILE = "mana/mana-Info.plist";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../libs\"",
+					/opt/local/lib,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-DHAS_SOCKLEN_T";
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-lbz2",
+					"-lcurl",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		FC0479E6151E4DB800C5E9E7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = /Library/Frameworks;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				GCC_PREFIX_HEADER = "";
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				"GCC_SYMBOLS_PRIVATE_EXTERN[arch=i386]" = YES;
+				HEADER_SEARCH_PATHS = (
+					../src,
+					../src/cpp0x_compat,
+					../libs/enet/include,
+					/Library/Frameworks/SDL.framework/Headers,
+					/opt/local/include/libxml2,
+					/opt/local/include/SDL,
+					/opt/local/include,
+					/Library/Frameworks/SDL_mixer.framework/Headers,
+					/Library/Frameworks/SDL_image.framework/Headers,
+				);
+				INFOPLIST_FILE = "mana/mana-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/../libs\"",
+					/opt/local/lib,
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.6;
+				OTHER_CFLAGS = "-DHAS_SOCKLEN_T";
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-lbz2",
+					"-lcurl",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		FC0479C0151E4DB700C5E9E7 /* Build configuration list for PBXProject "mana10.7" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC0479E2151E4DB800C5E9E7 /* Debug */,
+				FC0479E3151E4DB800C5E9E7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FC0479E4151E4DB800C5E9E7 /* Build configuration list for PBXNativeTarget "mana" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FC0479E5151E4DB800C5E9E7 /* Debug */,
+				FC0479E6151E4DB800C5E9E7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = FC0479BD151E4DB700C5E9E7 /* Project object */;
+}

--- a/Xcode/mana10.7.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Xcode/mana10.7.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:mana.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/src/resources/music.h
+++ b/src/resources/music.h
@@ -24,11 +24,8 @@
 
 #include "resources/resource.h"
 
-#ifdef __APPLE__
-#include <SDL/SDL_mixer.h>
-#else
 #include <SDL_mixer.h>
-#endif
+
 
 /**
  * Defines a class for loading and storing music.

--- a/src/resources/soundeffect.h
+++ b/src/resources/soundeffect.h
@@ -24,11 +24,7 @@
 
 #include "resources/resource.h"
 
-#ifdef __APPLE__
-#include <SDL/SDL_mixer.h>
-#else
 #include <SDL_mixer.h>
-#endif
 
 /**
  * Defines a class for loading and storing sound effects.

--- a/src/sound.h
+++ b/src/sound.h
@@ -22,11 +22,7 @@
 #ifndef SOUND_H
 #define SOUND_H
 
-#ifdef __APPLE__
-#include <SDL/SDL_mixer.h>
-#else
 #include <SDL_mixer.h>
-#endif
 
 #include <string>
 


### PR DESCRIPTION
Source:
- Removed #ifdef **APPLE** for SDL_mixer.h (see Xcode changes).

Xcode project:
- New mana10.7 Xcode project (maybe unnecessary?)
- Added -DHAS_SOCKLEN_T to CFLAGS.
- Added /opt/local/lib to library search path.
- Added /Library/Frameworks to frameworks search path.
- Added /Library/Frameworks/SDL_mixer.framework/Headers & SDL_image.framework/Headers to Header search path.
- Fixed icon location.
- Updated project to 10.7 SDK.

It would be great if another OSX user could test this out. Thank you.
