### PR TITLE
Fixed issue where previous special entries were drawn underneath

### DIFF
--- a/src/gui/specialswindow.cpp
+++ b/src/gui/specialswindow.cpp
@@ -152,6 +152,13 @@ void SpecialsWindow::draw(gcn::Graphics *graphics)
 
 void SpecialsWindow::rebuild(const std::map<int, Special> &specialData)
 {
+    // remove current entries so they don't get drawn underneath
+    for (std::map<int, SpecialEntry*>::const_iterator i = mEntries.begin();
+         i != mEntries.end(); i++)
+    {
+        remove(i->second);
+    }
+
     make_dtor(mEntries);
     mEntries.clear();
     int vPos = 0; //vertical position of next placed element


### PR DESCRIPTION
Fixed a problem where the previous special entriess were drawn underneath because they were still part of the window.
