### PR TITLE
Give feedback when guild invite failed

### DIFF
--- a/src/net/manaserv/guildhandler.cpp
+++ b/src/net/manaserv/guildhandler.cpp
@@ -105,6 +105,10 @@ void GuildHandler::handleMessage(MessageIn &msg)
             {
                 SERVER_NOTICE(_("Invited player can't join another guild."));
             }
+            else // any other failure
+            {
+                SERVER_NOTICE(_("Invite failed."));
+            }
         } break;
 
         case CPMSG_GUILD_ACCEPT_RESPONSE:


### PR DESCRIPTION
Server was already sending a error message. But the client ignored it.
