### PR TITLE
Added support charcreation.xml settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -369,6 +369,8 @@ SET(SRCS
     resources/attributes.h
     resources/beinginfo.cpp
     resources/beinginfo.h
+    resources/chardb.cpp
+    resources/chardb.h
     resources/dye.cpp
     resources/dye.h
     resources/emotedb.cpp

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -64,6 +64,7 @@
 #include "net/net.h"
 #include "net/worldinfo.h"
 
+#include "resources/chardb.h"
 #include "resources/hairdb.h"
 #include "resources/emotedb.h"
 #include "resources/image.h"
@@ -451,6 +452,7 @@ Client::~Client()
     SDL_RemoveTimer(mSecondsCounterId);
 
     // Unload XML databases
+    CharDB::unload();
     hairDB.unload();
     EmoteDB::unload();
     delete itemDb;
@@ -762,6 +764,7 @@ int Client::exec()
                     Event::trigger(Event::ClientChannel, Event::LoadingDatabases);
 
                     // Load XML databases
+                    CharDB::load();
                     hairDB.load();
                     switch (Net::getNetworkType())
                     {

--- a/src/gui/charcreatedialog.cpp
+++ b/src/gui/charcreatedialog.cpp
@@ -41,6 +41,7 @@
 #include "net/charhandler.h"
 #include "net/net.h"
 
+#include "resources/chardb.h"
 #include "resources/hairdb.h"
 
 #include "utils/gettext.h"
@@ -55,6 +56,10 @@ CharCreateDialog::CharCreateDialog(CharSelectDialog *parent, int slot):
 {
     mPlayer = new Being(0, ActorSprite::PLAYER, 0, NULL);
     mPlayer->setGender(GENDER_MALE);
+
+    const std::vector<int> &items = CharDB::getDefaultItems();
+    for (size_t i = 0; i < items.size(); ++i)
+        mPlayer->setSprite(i + 1, items.at(i));
 
     mHairStylesIds = hairDB.getHairStyleIds(
         Net::getCharHandler()->getCharCreateMaxHairStyleId());
@@ -196,7 +201,9 @@ void CharCreateDialog::action(const gcn::ActionEvent &event)
         }
     }
     else if (event.getId() == "cancel")
+    {
         scheduleDelete();
+    }
     else if (event.getId() == "nextcolor")
     {
         ++mHairColorId;

--- a/src/net/tmwa/charserverhandler.cpp
+++ b/src/net/tmwa/charserverhandler.cpp
@@ -39,6 +39,7 @@
 #include "net/tmwa/protocol.h"
 
 #include "resources/attributes.h"
+#include "resources/chardb.h"
 #include "resources/hairdb.h"
 
 #include "utils/dtor.h"
@@ -279,10 +280,17 @@ void CharServerHandler::setCharCreateDialog(CharCreateDialog *window)
     const Token &token =
             static_cast<LoginHandler*>(Net::getLoginHandler())->getToken();
 
-    mCharCreateDialog->setAttributes(attributes,
-                                     Attributes::getCreationPoints(),
-                                     Attributes::getAttributeMinimum(),
-                                     Attributes::getAttributeMaximum());
+    unsigned minStat = CharDB::getMinStat();
+    if (minStat == 0)
+        minStat = Attributes::getAttributeMinimum();
+    unsigned maxStat = CharDB::getMaxStat();
+    if (maxStat == 0)
+        maxStat = Attributes::getAttributeMaximum();
+    unsigned sumStat = CharDB::getSumStat();
+    if (sumStat == 0)
+        sumStat = Attributes::getCreationPoints();
+
+    mCharCreateDialog->setAttributes(attributes, sumStat, minStat, maxStat);
     mCharCreateDialog->setFixedGender(true, token.sex);
 }
 
@@ -344,6 +352,18 @@ unsigned int CharServerHandler::hairSprite() const
 unsigned int CharServerHandler::maxSprite() const
 {
     return SPRITE_VECTOREND;
+}
+
+int CharServerHandler::getCharCreateMaxHairColorId() const
+{
+    const int max = CharDB::getMaxHairColor();
+    return max ? max : 11; // default maximum
+}
+
+int CharServerHandler::getCharCreateMaxHairStyleId() const
+{
+    const int max = CharDB::getMaxHairStyle();
+    return max ? max : 19; // default maximum
 }
 
 void CharServerHandler::connect()

--- a/src/net/tmwa/charserverhandler.h
+++ b/src/net/tmwa/charserverhandler.h
@@ -69,15 +69,8 @@ class CharServerHandler : public MessageHandler, public Net::CharHandler
 
         unsigned int maxSprite() const;
 
-        // Must be < 12 at character creation time, but can be higher
-        // after that.
-        int getCharCreateMaxHairColorId() const
-        { return 11; }
-
-        // Must be < 20 at character creation time, but can be higher
-        // after that.
-        int getCharCreateMaxHairStyleId() const
-        { return 19; }
+        int getCharCreateMaxHairColorId() const;
+        int getCharCreateMaxHairStyleId() const;
 
         void connect();
 

--- a/src/resources/chardb.cpp
+++ b/src/resources/chardb.cpp
@@ -1,0 +1,132 @@
+/*
+ *  Character creation settings
+ *  Copyright (C) 2011-2013  The ManaPlus Developers
+ *  Copyright (C) 2013  The Mana Developers
+ *
+ *  This file is part of The ManaPlus Client.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "resources/chardb.h"
+
+#include "log.h"
+
+#include "utils/xml.h"
+
+namespace
+{
+    bool mLoaded = false;
+    unsigned mMinHairColor = 0;
+    unsigned mMaxHairColor = 0;
+    unsigned mMinHairStyle = 0;
+    unsigned mMaxHairStyle = 0;
+    unsigned mMinStat = 0;
+    unsigned mMaxStat = 0;
+    unsigned mSumStat = 0;
+    std::vector<int> mDefaultItems;
+}
+
+static void loadMinMax(xmlNodePtr node, unsigned *min, unsigned *max)
+{
+    *min = XML::getProperty(node, "min", 1);
+    *max = XML::getProperty(node, "max", 10);
+}
+
+void CharDB::load()
+{
+    if (mLoaded)
+        unload();
+
+    XML::Document doc("charcreation.xml");
+    xmlNodePtr root = doc.rootNode();
+
+    if (!root || !xmlStrEqual(root->name, BAD_CAST "chars"))
+    {
+        logger->log("CharDB: Failed to parse charcreation.xml.");
+        return;
+    }
+
+    for_each_xml_child_node(node, root)
+    {
+        if (xmlStrEqual(node->name, BAD_CAST "haircolor"))
+        {
+            loadMinMax(node, &mMinHairColor, &mMaxHairColor);
+        }
+        else if (xmlStrEqual(node->name, BAD_CAST "hairstyle"))
+        {
+            loadMinMax(node, &mMinHairStyle, &mMaxHairStyle);
+        }
+        else if (xmlStrEqual(node->name, BAD_CAST "stat"))
+        {
+            loadMinMax(node, &mMinStat, &mMaxStat);
+            mSumStat = XML::getProperty(node, "sum", 0);
+        }
+        else if (xmlStrEqual(node->name, BAD_CAST "item"))
+        {
+            const int id = XML::getProperty(node, "id", 0);
+            if (id > 0)
+                mDefaultItems.push_back(id);
+        }
+    }
+
+    mLoaded = true;
+}
+
+void CharDB::unload()
+{
+    logger->log("Unloading chars database...");
+
+    mLoaded = false;
+}
+
+unsigned CharDB::getMinHairColor()
+{
+    return mMinHairColor;
+}
+
+unsigned CharDB::getMaxHairColor()
+{
+    return mMaxHairColor;
+}
+
+unsigned CharDB::getMinHairStyle()
+{
+    return mMinHairStyle;
+}
+
+unsigned CharDB::getMaxHairStyle()
+{
+    return mMaxHairStyle;
+}
+
+unsigned CharDB::getMinStat()
+{
+    return mMinStat;
+}
+
+unsigned CharDB::getMaxStat()
+{
+    return mMaxStat;
+}
+
+unsigned CharDB::getSumStat()
+{
+    return mSumStat;
+}
+
+const std::vector<int> &CharDB::getDefaultItems()
+{
+    return mDefaultItems;
+}

--- a/src/resources/chardb.h
+++ b/src/resources/chardb.h
@@ -1,0 +1,48 @@
+/*
+ *  Character creation settings
+ *  Copyright (C) 2011-2013  The ManaPlus Developers
+ *  Copyright (C) 2013  The Mana Developers
+ *
+ *  This file is part of The ManaPlus Client.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef RESOURCES_CHARDB_H
+#define RESOURCES_CHARDB_H
+
+#include <vector>
+
+/**
+ * Character creation settings.
+ */
+namespace CharDB
+{
+    void load();
+    void unload();
+
+    unsigned getMinHairColor();
+    unsigned getMaxHairColor();
+
+    unsigned getMinHairStyle();
+    unsigned getMaxHairStyle();
+
+    unsigned getMinStat();
+    unsigned getMaxStat();
+    unsigned getSumStat();
+
+    const std::vector<int> &getDefaultItems();
+}
+
+#endif // RESOURCES_CHARDB_H


### PR DESCRIPTION
This file was introduced by ManaPlus as a way of configuring the character creation process. It defines the number of hair styles and colors, how stat points should be divided and what the starting equipment of the player is.

The minimum and maximum hair color/style IDs are not supported at the moment.

This is mostly a backport of ManaPlus commits 10cf52b5 and dcc18eba, with some style changes.

Mantis-issue: 501
