### PR TITLE
Fixed network layer doing delayed actor deletion

### DIFF
--- a/src/actorspritemanager.cpp
+++ b/src/actorspritemanager.cpp
@@ -138,7 +138,14 @@ FloorItem *ActorSpriteManager::createItem(int id, int itemId, const Vector &pos)
     return floorItem;
 }
 
-void ActorSpriteManager::destroy(ActorSprite *actor)
+void ActorSpriteManager::destroyActor(ActorSprite *actor)
+{
+    mActors.erase(actor);
+    mDeleteActors.erase(actor);
+    delete actor;
+}
+
+void ActorSpriteManager::scheduleDelete(ActorSprite *actor)
 {
     if (!actor || actor == local_player)
         return;

--- a/src/actorspritemanager.h
+++ b/src/actorspritemanager.h
@@ -67,10 +67,15 @@ class ActorSpriteManager
         FloorItem *createItem(int id, int itemId, const Vector &position);
 
         /**
+         * Immediately destroys the given \a actor.
+         */
+        void destroyActor(ActorSprite *actor);
+
+        /**
          * Destroys the given ActorSprite at the end of
          * ActorSpriteManager::logic.
          */
-        void destroy(ActorSprite *actor);
+        void scheduleDelete(ActorSprite *actor);
 
         /**
          * Returns a specific Being, by id;

--- a/src/being.cpp
+++ b/src/being.cpp
@@ -892,7 +892,7 @@ void Being::logic()
     {
 
         if (getType() != PLAYER)
-            actorSpriteManager->destroy(this);
+            actorSpriteManager->scheduleDelete(this);
     }
 }
 

--- a/src/net/manaserv/beinghandler.cpp
+++ b/src/net/manaserv/beinghandler.cpp
@@ -176,7 +176,7 @@ void BeingHandler::handleBeingLeaveMessage(MessageIn &msg)
     if (!being)
         return;
 
-    actorSpriteManager->destroy(being);
+    actorSpriteManager->destroyActor(being);
 }
 
 void BeingHandler::handleBeingsMoveMessage(MessageIn &msg)

--- a/src/net/manaserv/itemhandler.cpp
+++ b/src/net/manaserv/itemhandler.cpp
@@ -60,7 +60,7 @@ void ItemHandler::handleMessage(MessageIn &msg)
                 }
                 else if (FloorItem *item = actorSpriteManager->findItem(id))
                 {
-                    actorSpriteManager->destroy(item);
+                    actorSpriteManager->destroyActor(item);
                 }
             }
         } break;

--- a/src/net/tmwa/beinghandler.cpp
+++ b/src/net/tmwa/beinghandler.cpp
@@ -327,7 +327,7 @@ void BeingHandler::handleMessage(MessageIn &msg)
             if (msg.readInt8() == 1)
                 dstBeing->setAction(Being::DEAD);
             else
-                actorSpriteManager->destroy(dstBeing);
+                actorSpriteManager->destroyActor(dstBeing);
 
             break;
 

--- a/src/net/tmwa/itemhandler.cpp
+++ b/src/net/tmwa/itemhandler.cpp
@@ -67,7 +67,7 @@ void ItemHandler::handleMessage(MessageIn &msg)
 
         case SMSG_ITEM_REMOVE:
             if (FloorItem *item = actorSpriteManager->findItem(msg.readInt32()))
-                actorSpriteManager->destroy(item);
+                actorSpriteManager->destroyActor(item);
             break;
     }
 }


### PR DESCRIPTION
The delayed actor deletion was meant to be used during the logic calls, to avoid modifying the container while it is being iterated. The deletions happening from the network layer are not done while iterating the set of actors, so it can delete immediately.

This fixes an issue where an NPC would disappear when changing appearance on tmwAthena, because this was implemented as a remove + add, which broke due to the delayed deletion.

Mantis-issue: 507
